### PR TITLE
flowtype: no more `|| exit 0` in npm script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 ## Unreleased
 
 
+### Fixed
+
+-   flowtype: no more `|| exit 0` in npm script (#42, #43)
+
+
 ## 1.5.0 - 2016-10-19
 
 

--- a/lib/tasks/flowtype.js
+++ b/lib/tasks/flowtype.js
@@ -27,7 +27,7 @@ function npmInstall (cwd /* : string */) {
 function npmScript (cwd /* : string */) {
   return updateJson(path.join(cwd, 'package.json'), (pkg) => {
     pkg.scripts = pkg.scripts || {}
-    pkg.scripts.flow_check = 'flow check || exit 0'
+    pkg.scripts.flow_check = 'flow check'
     return pkg
   })
 }


### PR DESCRIPTION
### Fixed

-   flowtype: no more `|| exit 0` in npm script (#42, #43)
