### PR TITLE
add `npm run` scripts for detected test runners

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,4 @@ cache:
     - node_modules
 node_js:
   - '6'
+  - '7'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 ## Unreleased
 
 
+### Added
+
+-   add `npm run ava` if using [ava](https://github.com/avajs/ava)
+
+-   add `npm run jest` if using [jest](https://github.com/facebook/jest)
+
+-   add `npm run mocha` if using [mocha](https://github.com/mochajs/mocha)
+
+-   add `npm run nyc` if using [nyc](https://github.com/istanbuljs/nyc)
+
+
 ### Fixed
 
 -   flowtype: no more `|| exit 0` in npm script (#42, #43)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ node-init --help
 
 -   installs and configures [FlowType](https://flowtype.org/) and `npm run flow_check`
 
+-   add `npm run ava` if using [ava](https://github.com/avajs/ava)
+
+-   add `npm run jest` if using [jest](https://github.com/facebook/jest)
+
+-   add `npm run mocha` if using [mocha](https://github.com/mochajs/mocha)
+
+-   add `npm run nyc` if using [nyc](https://github.com/istanbuljs/nyc)
+
 
 ### Continuous Integration
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# jokeyrhyme / node-init [![npm](https://img.shields.io/npm/v/@jokeyrhyme/node-init.svg?maxAge=2592000)](https://www.npmjs.com/package/@jokeyrhyme/node-init) [![AppVeyor Status](https://ci.appveyor.com/api/projects/status/0aypflvt21tpjfiu?svg=true)](https://ci.appveyor.com/project/jokeyrhyme/node-init-js)
-[![Travis CI Status](https://travis-ci.org/jokeyrhyme/node-init.js.svg?branch=master)](https://travis-ci.org/jokeyrhyme/node-init.js)
+# jokeyrhyme / node-init [![npm](https://img.shields.io/npm/v/@jokeyrhyme/node-init.svg?maxAge=2592000)](https://www.npmjs.com/package/@jokeyrhyme/node-init) [![AppVeyor Status](https://ci.appveyor.com/api/projects/status/0aypflvt21tpjfiu?svg=true)](https://ci.appveyor.com/project/jokeyrhyme/node-init-js) [![Travis CI Status](https://travis-ci.org/jokeyrhyme/node-init.js.svg?branch=master)](https://travis-ci.org/jokeyrhyme/node-init.js)
 
 impose my will upon a new or existing Node.js project
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@ build: 'off'
 environment:
   matrix:
     - nodejs_version: '6'
+    - nodejs_version: '7'
 install:
   - ps: 'Install-Product node $env:nodejs_version'
   - npm install

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,6 +26,7 @@ const npmEngines = require('./tasks/npm-engines.js')
 const npmInit = require('./tasks/npm-init.js')
 const npmName = require('./tasks/npm-name.js')
 const npmPublishConfig = require('./tasks/npm-publish-config.js')
+const npmTest = require('./tasks/npm-test.js')
 const travisYml = require('./tasks/travis.yml.js')
 
 let projectDir = process.cwd()
@@ -96,6 +97,7 @@ function init ([ dir ] /* : Array<string> */, flags /* : Flags */) {
       npmPublishConfig,
       eslint,
       flowtype,
+      npmTest,
       fixpack, // should be near last
       npmDevDeps // should be last
     ], { cwd: projectDir, scope }))

--- a/lib/tasks/npm-test.js
+++ b/lib/tasks/npm-test.js
@@ -1,0 +1,57 @@
+/* @flow */
+'use strict'
+
+const path = require('path')
+
+const { updateJson } = require('../json.js')
+
+const LABEL = '`npm test` executes installed test runners'
+
+/* :: import type { TaskOptions } from '../index.js' */
+
+function fn ({ cwd, scope } /* : TaskOptions */) {
+  return updateJson(
+    path.join(cwd, 'package.json'),
+    (pkg) => {
+      if (pkg.devDependencies.ava) {
+        pkg.scripts = Object.assign({}, pkg.scripts, {
+          ava: 'ava'
+        })
+        if (pkg.devDependencies.nyc) {
+          pkg.scripts = Object.assign({}, pkg.scripts, {
+            ava: 'nyc ava',
+            nyc: 'nyc check-coverage'
+          })
+        }
+      }
+
+      if (pkg.devDependencies.jest) {
+        pkg.scripts = Object.assign({}, pkg.scripts, {
+          jest: 'jest'
+        })
+        pkg.jest = Object.assign({}, pkg.jest, {
+          collectCoverage: true,
+          coverageThreshold: {
+            global: {
+              lines: 90
+            }
+          },
+          testRegex: '/__tests__/[^\\/]*\\.js$'
+        })
+      }
+
+      if (pkg.devDependencies.mocha) {
+        pkg.scripts = Object.assign({}, pkg.scripts, {
+          mocha: 'mocha'
+        })
+      }
+
+      return pkg
+    }
+  )
+}
+
+module.exports = {
+  fn,
+  label: LABEL
+}

--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
     "ava": "nyc ava",
     "eslint": "eslint --fix --cache .",
     "fixpack": "fixpack",
-    "flow_check": "flow check || exit 0",
-    "nyc": "nyc check-coverage --branches 90 --functions 90 --lines 90 --statements 90",
+    "flow_check": "flow check",
+    "nyc": "nyc check-coverage",
     "postpublish": "greenkeeper-postpublish",
     "posttest": "npm run eslint && npm run flow_check && npm run fixpack",
     "test": "npm run ava && npm run nyc"


### PR DESCRIPTION
### Added

-   add `npm run ava` if using [ava](https://github.com/avajs/ava)

-   add `npm run jest` if using [jest](https://github.com/facebook/jest)

-   add `npm run mocha` if using [mocha](https://github.com/mochajs/mocha)

-   add `npm run nyc` if using [nyc](https://github.com/istanbuljs/nyc)


