### PR TITLE
AppVeyor: use 64-bit Node.js, no `npm cache clean`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 
 ### Fixed
 
+-   no `npm cache clean` instructions for AppVeyor
+
+-   install 64-bit Node.js in AppVeyor
+
 -   flowtype: no more `|| exit 0` in npm script (#42, #43)
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,10 +4,9 @@ environment:
     - nodejs_version: '6'
     - nodejs_version: '7'
 install:
-  - ps: 'Install-Product node $env:nodejs_version'
+  - ps: 'Install-Product node $env:nodejs_version x64'
   - npm install
 test_script:
   - node --version
   - npm --version
-  - npm cache clean
   - npm test

--- a/lib/tasks/appveyor.yml.js
+++ b/lib/tasks/appveyor.yml.js
@@ -6,6 +6,7 @@ const path = require('path')
 const { safeDump, safeLoad } = require('js-yaml')
 const semver = require('semver')
 const union = require('lodash.union')
+const without = require('lodash.without')
 
 const fs = require('../fs.js')
 const { getBitbucketPath, getGitHubPath, getOriginUrl } = require('../git.js')
@@ -39,11 +40,23 @@ function fn ({ cwd } /* : TaskOptions */) {
           }
 
           cfg.install = cfg.install || []
+
+          // fix any non-64-bit Node.js install steps
+          cfg.install = cfg.install.map((step) => {
+            if (step.ps === 'Install-Product node $env:nodejs_version') {
+              return {
+                ps: 'Install-Product node $env:nodejs_version x64'
+              }
+            }
+            return step
+          })
+
           if (cfg.install.every((step) => {
-            return step.ps !== 'Install-Product node $env:nodejs_version'
+            return step.ps !== 'Install-Product node $env:nodejs_version x64'
           })) {
-            cfg.install.push({ ps: 'Install-Product node $env:nodejs_version' })
+            cfg.install.push({ ps: 'Install-Product node $env:nodejs_version x64' })
           }
+
           if (cfg.install.every((step) => {
             return step !== 'npm install'
           })) {
@@ -54,12 +67,15 @@ function fn ({ cwd } /* : TaskOptions */) {
           cfg.test_script = union(cfg.test_script, [
             'node --version',
             'npm --version',
-            'npm cache clean',
             'npm test'
           ])
 
+          // anything to do with npm's cache is likely to cause EPERMs
+          cfg.install = without(cfg.install, 'npm cache clean')
+          cfg.test_script = without(cfg.test_script, 'npm cache clean')
+
           if (Array.isArray(cfg.cache)) {
-            cfg.cache = cfg.cache.filter((value) => value !== 'node_modules')
+            cfg.cache = without(cfg.cache, 'node_modules')
           }
 
           return safeDump(cfg)


### PR DESCRIPTION
### Fixed

-   no `npm cache clean` instructions for AppVeyor

-   install 64-bit Node.js in AppVeyor

