### PR TITLE
notify users about old Node.js versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
 
 -   add `npm run nyc` if using [nyc](https://github.com/istanbuljs/nyc)
 
+-   stop execution if user's Node.js version doesn't match our package.json "engines"
+
+-   tell users (via [package-engines-notifier](https://github.com/jokeyrhyme/package-engines-notifier.js)) if their Node.js doesn't match our package.json "engines"
+
+-   tell users (via [update-nodejs-notifier](https://github.com/jokeyrhyme/update-nodejs-notifier.js)) if the major version of their Node.js is older than the current stable
+
 
 ### Fixed
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -3,12 +3,15 @@
 'use strict'
 
 const meow = require('meow')
+const { enginesNotify } = require('package-engines-notifier')
+const { updateNodejsNotifier } = require('update-nodejs-notifier')
 const updateNotifier = require('update-notifier')
 
 const pkg = require('../package.json')
-const init = require('../lib/index.js').init
 
 updateNotifier({ pkg }).notify()
+
+updateNodejsNotifier()
 
 const cli = meow(`
 Usage:
@@ -25,4 +28,11 @@ Examples
   string: [ 'scope' ]
 })
 
-init(cli.input, cli.flags)
+if (!enginesNotify({ pkg: pkg })) {
+  // no engine trouble, proceed :)
+  const { init } = require('../lib/index.js')
+
+  init(cli.input, cli.flags)
+} else {
+  process.exitCode = 1
+}

--- a/package.json
+++ b/package.json
@@ -21,9 +21,11 @@
     "lodash.without": "^4.3.0",
     "meow": "3.7.0",
     "node-fetch": "1.6.3",
+    "package-engines-notifier": "1.0.0",
     "semver": "^5.3.0",
     "through2": "2.0.1",
-    "update-notifier": "^1.0.2",
+    "update-nodejs-notifier": "1.0.1",
+    "update-notifier": "1.0.2",
     "vinyl-fs": "2.4.4",
     "write-json-file": "2.0.0"
   },


### PR DESCRIPTION
### Added

-   stop execution if user's Node.js version doesn't match our package.json "engines"

-   tell users (via [package-engines-notifier](https://github.com/jokeyrhyme/package-engines-notifier.js)) if their Node.js doesn't match our package.json "engines"

-   tell users (via [update-nodejs-notifier](https://github.com/jokeyrhyme/update-nodejs-notifier.js)) if the major version of their Node.js is older than the current stable
