### PR TITLE
fresh projects no longer throw `TypeError`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 -   `node-init` no longer unexpectedly breaks ESLint plugin configuration
 
+-   fresh projects no longer cause `TypeError`s to throw (#61)
+
 
 ## 1.7.0 - 2016-11-03
 

--- a/lib/tasks/appveyor.yml.js
+++ b/lib/tasks/appveyor.yml.js
@@ -30,7 +30,7 @@ function fn ({ cwd } /* : TaskOptions */) {
         .then(() => fs.readFile(filePath, 'utf8'))
         .then((contents) => Promise.all([
           safeLoad(contents),
-          readPkgUp()
+          readPkgUp({ cwd })
             .then(({ pkg }) => fetchSupportedMajors((pkg.engines || {}).node))
         ]))
         .then(([ cfg, majors ]) => {

--- a/lib/tasks/npm-test.js
+++ b/lib/tasks/npm-test.js
@@ -14,11 +14,12 @@ function fn ({ cwd, scope } /* : TaskOptions */) {
   return updateJson(
     path.join(cwd, 'package.json'),
     (pkg) => {
-      if (pkg.devDependencies.ava) {
+      const devDeps = pkg.devDependencies || {}
+      if (devDeps.ava) {
         pkg.scripts = Object.assign({}, pkg.scripts, {
           ava: 'ava'
         })
-        if (pkg.devDependencies.nyc) {
+        if (devDeps.nyc) {
           pkg.scripts = Object.assign({}, pkg.scripts, {
             ava: 'nyc ava',
             nyc: 'nyc check-coverage'
@@ -26,7 +27,7 @@ function fn ({ cwd, scope } /* : TaskOptions */) {
         }
       }
 
-      if (pkg.devDependencies.jest) {
+      if (devDeps.jest) {
         pkg.scripts = Object.assign({}, pkg.scripts, {
           jest: 'jest'
         })
@@ -41,7 +42,7 @@ function fn ({ cwd, scope } /* : TaskOptions */) {
         })
       }
 
-      if (pkg.devDependencies.mocha) {
+      if (devDeps.mocha) {
         pkg.scripts = Object.assign({}, pkg.scripts, {
           mocha: 'mocha'
         })

--- a/lib/tasks/travis.yml.js
+++ b/lib/tasks/travis.yml.js
@@ -22,7 +22,7 @@ function fn ({ cwd } /* : TaskOptions */) {
   const filePath = path.join(cwd, '.travis.yml')
   return Promise.all([
     getOriginUrl(cwd),
-    readPkgUp()
+    readPkgUp({ cwd })
       .then(({ pkg }) => fetchSupportedMajors((pkg.engines || {}).node))
   ])
     .then(([ originUrl, majors ]) => {


### PR DESCRIPTION
### Fixed

-   fresh projects no longer cause `TypeError`s to throw (fixes #61)
