### PR TITLE
fix `npm init -y` "dependencies" bloat (fixes #96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 -   GitLab CI integration for non-BitBucket non-GitHub projects (#75)
 
 
+### Fixed
+
+-   prevent `npm init -y` from populating "dependencies" (#96)
+
+
 ## 1.8.1 - 2017-02-02
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 -   prevent `npm init -y` from populating "dependencies" (#96)
 
+-   fix regression for fresh .eslintrc.json and jsconfig.json files
+
 
 ## 1.8.1 - 2017-02-02
 

--- a/lib/tasks/npm-init.js
+++ b/lib/tasks/npm-init.js
@@ -4,8 +4,9 @@
 const path = require('path')
 
 const execa = require('execa')
+const updateJsonFile = require('update-json-file')
 
-const { GIT_REPO, PACKAGE_JSON } = require('../values.js')
+const { GIT_REPO, JSON_OPTIONS, PACKAGE_JSON } = require('../values.js')
 
 const LABEL = 'npm package.json initialised'
 
@@ -13,6 +14,11 @@ const LABEL = 'npm package.json initialised'
 
 function fn ({ cwd } /* : TaskOptions */) {
   return execa('npm', ['init', '-y'], { cwd })
+    .then(() => updateJsonFile(path.join(cwd, 'package.json'), (pkg) => {
+      // https://github.com/jokeyrhyme/node-init.js/issues/96
+      pkg.dependencies = pkg.dependencies || {}
+      return pkg
+    }, JSON_OPTIONS))
 }
 
 module.exports = {

--- a/lib/tasks/npm-name.js
+++ b/lib/tasks/npm-name.js
@@ -2,6 +2,7 @@
 'use strict'
 
 const path = require('path')
+
 const updateJsonFile = require('update-json-file')
 
 const { injectScope } = require('../pkg.js')

--- a/lib/values.js
+++ b/lib/values.js
@@ -7,6 +7,7 @@ const PACKAGE_JSON_DEVDEPS = 'PACKAGE_JSON_DEVDEPS'
 const PACKAGE_JSON_NAME = 'PACKAGE_JSON_NAME'
 
 const JSON_OPTIONS = {
+  defaultValue: {},
   indent: 2
 }
 


### PR DESCRIPTION
### Fixed

-   prevent `npm init -y` from populating "dependencies" (#96)

-   fix regression for fresh .eslintrc.json and jsconfig.json files
