### PR TITLE
drop old greenkeeper-postpublish integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 ## Unreleased
 
 
+### Fixed
+
+-   drop old [greenkeeper-postpublish](https://github.com/greenkeeperio/greenkeeper-postpublish) integration
+
+
 ## 1.9.0 - 2017-02-02
 
 

--- a/lib/tasks/greenkeeper.js
+++ b/lib/tasks/greenkeeper.js
@@ -1,0 +1,47 @@
+/* @flow */
+'use strict'
+
+const path = require('path')
+
+const updateJsonFile = require('update-json-file')
+
+const { JSON_OPTIONS, PACKAGE_JSON } = require('../values.js')
+
+const LABEL = 'greenkeeper.io integration'
+
+/* :: import type { PackageJSON, TaskOptions } from '../types.js' */
+
+function pkgUpdater (pkg /* : PackageJSON */) {
+  // greenkeeper no longer requires publish-hook integration
+  const { devDependencies = {}, scripts = {} } = pkg
+
+  delete (devDependencies || {})['greenkeeper-postpublish']
+  if (!Object.keys(devDependencies).length) {
+    delete pkg.devDependencies
+  }
+
+  if (scripts.postpublish === 'greenkeeper-postpublish') {
+    delete scripts.postpublish
+  }
+  if (!Object.keys(scripts).length) {
+    delete pkg.scripts
+  }
+
+  return pkg
+}
+
+function fn ({ cwd, scope } /* : TaskOptions */) {
+  return updateJsonFile(
+    path.join(cwd, 'package.json'),
+    pkgUpdater,
+    JSON_OPTIONS
+  )
+}
+
+module.exports = {
+  fn,
+  id: path.basename(__filename),
+  label: LABEL,
+  pkgUpdater,
+  requires: [ PACKAGE_JSON ]
+}

--- a/lib/types.js
+++ b/lib/types.js
@@ -21,6 +21,7 @@ export type PackageJSON = {
   name: string,
   optionalDependencies?: PackageJSONDependencies,
   peerDependencies?: PackageJSONDependencies,
+  scripts?: { [id: string]: string },
   version: string
 }
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "ava": "^0.18.1",
     "eslint": "^3.8.1",
-    "eslint-config-standard": "^6.2.0",
+    "eslint-config-standard": "^7.0.0",
     "eslint-plugin-ava": "^4.0.0",
     "eslint-plugin-node": "^4.0.0",
     "eslint-plugin-promise": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "eslint-plugin-standard": "^2.0.1",
     "fixpack": "^2.3.1",
     "flow-bin": "^0.41.0",
-    "greenkeeper-postpublish": "^1.0.0",
     "nyc": "^10.0.0"
   },
   "directories": {
@@ -71,7 +70,6 @@
     "fixpack": "fixpack",
     "flow_check": "flow check",
     "nyc": "nyc check-coverage --lines 40",
-    "postpublish": "greenkeeper-postpublish",
     "posttest": "npm run eslint && npm run flow_check && npm run fixpack",
     "test": "npm run ava && npm run nyc"
   }

--- a/test/tasks-greenkeeper.js
+++ b/test/tasks-greenkeeper.js
@@ -1,0 +1,36 @@
+/* @flow */
+'use strict'
+
+const test = require('ava')
+
+const { pkgUpdater } = require('../lib/tasks/greenkeeper.js')
+
+test('fresh package.json', (t) => {
+  const result = pkgUpdater({ name: 'my-package', version: '1.2.3' })
+  t.deepEqual(result, { name: 'my-package', version: '1.2.3' })
+})
+
+test('old package.json', (t) => {
+  const result = pkgUpdater({
+    name: 'my-package',
+    version: '1.2.3',
+    devDependencies: {
+      'greenkeeper-postpublish': '1.2.3',
+      something: '1.2.3'
+    },
+    scripts: {
+      postpublish: 'greenkeeper-postpublish',
+      test: 'exit 0'
+    }
+  })
+  t.deepEqual(result, {
+    name: 'my-package',
+    version: '1.2.3',
+    devDependencies: {
+      something: '1.2.3'
+    },
+    scripts: {
+      test: 'exit 0'
+    }
+  })
+})


### PR DESCRIPTION
### Fixed

-   drop old [greenkeeper-postpublish](https://github.com/greenkeeperio/greenkeeper-postpublish) integration
