### PR TITLE
use prettier instead of JavaScript Standard

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,11 +2,12 @@
   "extends": [
     "eslint:recommended",
     "plugin:node/recommended",
-    "standard",
     "plugin:ava/recommended"
   ],
   "plugins": [
     "ava",
-    "node"
+    "node",
+    "import",
+    "promise"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+-   use [prettier](https://github.com/prettier/prettier) for JavaScript code style
+
 -   [recommended React rules for ESLint](https://github.com/yannickcr/eslint-plugin-react) for React projects
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 ## Unreleased
 
 
+### Removed
+
+-   [JavaScript SemiStandard Style for ESLint](https://github.com/Flet/eslint-config-semistandard)
+
+-   [JavaScript Standard Style for ESLint](https://github.com/feross/eslint-config-standard)
+
+  -   [JavaScript Standard Style Plugin for ESLint](https://github.com/xjamundx/eslint-plugin-standard)
+
+-   [JavaScript Standard JSX Style for ESLint](https://github.com/feross/eslint-config-standard-jsx)
+
+-   [JavaScript Standard React Style for ESLint](https://github.com/feross/eslint-config-standard-react)
+
+
 ## 1.11.1 - 2017-04-05
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 ## Unreleased
 
 
+### Added
+
+-   [recommended React rules for ESLint](https://github.com/yannickcr/eslint-plugin-react) for React projects
+
+
 ### Removed
 
 -   [JavaScript SemiStandard Style for ESLint](https://github.com/Flet/eslint-config-semistandard)

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ node-init --help
 
 ### Code Quality
 
+-   installs and configures [prettier](https://github.com/prettier/prettier) and `npm run prettier`
+
 -   installs and configures [ESLint](http://eslint.org/), with [eslint-plugin-node](https://github.com/mysticatea/eslint-plugin-node)
 
 -   adds an `npm run eslint` script for ESLint

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ node-init --help
 
 ### Code Quality
 
--   installs and configures [ESLint](http://eslint.org/), with [JavaScript Standard Style](https://github.com/feross/eslint-config-standard) and [eslint-plugin-node](https://github.com/mysticatea/eslint-plugin-node)
+-   installs and configures [ESLint](http://eslint.org/), with [eslint-plugin-node](https://github.com/mysticatea/eslint-plugin-node)
 
 -   adds an `npm run eslint` script for ESLint
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,19 +1,20 @@
 #!/usr/bin/env node
 /* @flow */
-'use strict'
+'use strict';
 
-const meow = require('meow')
-const { enginesNotify } = require('package-engines-notifier')
-const { updateNodejsNotifier } = require('update-nodejs-notifier')
-const updateNotifier = require('update-notifier')
+const meow = require('meow');
+const { enginesNotify } = require('package-engines-notifier');
+const { updateNodejsNotifier } = require('update-nodejs-notifier');
+const updateNotifier = require('update-notifier');
 
-const pkg = require('../package.json')
+const pkg = require('../package.json');
 
-updateNotifier({ pkg }).notify()
+updateNotifier({ pkg }).notify();
 
-updateNodejsNotifier()
+updateNodejsNotifier();
 
-const cli = meow(`
+const cli = meow(
+  `
 Usage:
     $ node-init [project]
 
@@ -26,18 +27,20 @@ Examples
     $ node-init
     $ node-init my-project
     $ node-init my-project --scope my-org
-`, {
-  default: {
-    checkGitStatus: true
-  },
-  string: [ 'scope' ]
-})
+`,
+  {
+    default: {
+      checkGitStatus: true
+    },
+    string: ['scope']
+  }
+);
 
 if (!enginesNotify({ pkg: pkg })) {
   // no engine trouble, proceed :)
-  const { init } = require('../lib/index.js')
+  const { init } = require('../lib/index.js');
 
-  init(cli.input, cli.flags)
+  init(cli.input, cli.flags);
 } else {
-  process.exitCode = 1
+  process.exitCode = 1;
 }

--- a/lib/data.js
+++ b/lib/data.js
@@ -1,15 +1,15 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const without = require('lodash.without')
+const without = require('lodash.without');
 
-function ensureArrayTail (
+function ensureArrayTail(
   array /* : Array<any> */,
   value /* : any */
 ) /* : Array<any> */ {
-  return [ ...without(array, value), value ]
+  return [...without(array, value), value];
 }
 
 module.exports = {
   ensureArrayTail
-}
+};

--- a/lib/data.js
+++ b/lib/data.js
@@ -3,13 +3,6 @@
 
 const without = require('lodash.without')
 
-function ensureArrayHead (
-  array /* : Array<any> */,
-  value /* : any */
-) /* : Array<any> */ {
-  return [ value, ...without(array, value) ]
-}
-
 function ensureArrayTail (
   array /* : Array<any> */,
   value /* : any */
@@ -18,6 +11,5 @@ function ensureArrayTail (
 }
 
 module.exports = {
-  ensureArrayHead,
   ensureArrayTail
 }

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1,22 +1,23 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const fs = require('@jokeyrhyme/pify-fs')
+const fs = require('@jokeyrhyme/pify-fs');
 
-function copyFile (
+function copyFile(
   src /* : string */,
   dest /* : string */
 ) /* : Promise<void> */ {
-  return fs.readFile(src)
-    .then((data) => fs.writeFile(dest, data))
+  return fs.readFile(src).then(data => fs.writeFile(dest, data));
 }
 
-function touch (filePath) {
-  return fs.access(filePath)
-    .catch(() => fs.writeFile(filePath, ''))
+function touch(filePath) {
+  return fs.access(filePath).catch(() => fs.writeFile(filePath, ''));
 }
 
-module.exports = Object.assign({
-  copyFile,
-  touch
-}, fs)
+module.exports = Object.assign(
+  {
+    copyFile,
+    touch
+  },
+  fs
+);

--- a/lib/git.js
+++ b/lib/git.js
@@ -1,90 +1,85 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const execa = require('execa')
+const execa = require('execa');
 
-const MATCH_BB_HTTPS_REGEXP = /^https:\/\/[^@]+@bitbucket.org\/([^/]+\/[^/]+)\.git$/
-const MATCH_BB_SSH_REGEXP = /^\w+@bitbucket.org:([^/]+\/[^/]+)\.git$/
+const MATCH_BB_HTTPS_REGEXP = /^https:\/\/[^@]+@bitbucket.org\/([^/]+\/[^/]+)\.git$/;
+const MATCH_BB_SSH_REGEXP = /^\w+@bitbucket.org:([^/]+\/[^/]+)\.git$/;
 
-function getBitbucketPath (remoteUrl /* : string */) {
-  let bbPath
-  [ , bbPath ] = remoteUrl.match(MATCH_BB_HTTPS_REGEXP) || []
+function getBitbucketPath(remoteUrl /* : string */) {
+  let bbPath;
+  [, bbPath] = remoteUrl.match(MATCH_BB_HTTPS_REGEXP) || [];
   if (bbPath) {
-    return bbPath
+    return bbPath;
   }
-  [ , bbPath ] = remoteUrl.match(MATCH_BB_SSH_REGEXP) || []
+  [, bbPath] = remoteUrl.match(MATCH_BB_SSH_REGEXP) || [];
   if (bbPath) {
-    return bbPath
+    return bbPath;
   }
-  return ''
+  return '';
 }
 
-const MATCH_GH_HTTPS_REGEXP = /^https:\/\/github.com\/([^/]+\/[^/]+)\.git$/
-const MATCH_GH_SSH_REGEXP = /^\w+@github.com:([^/]+\/[^/]+)\.git$/
+const MATCH_GH_HTTPS_REGEXP = /^https:\/\/github.com\/([^/]+\/[^/]+)\.git$/;
+const MATCH_GH_SSH_REGEXP = /^\w+@github.com:([^/]+\/[^/]+)\.git$/;
 
-function getGitHubPath (remoteUrl /* : string */) {
-  let githubPath
-  [ , githubPath ] = remoteUrl.match(MATCH_GH_HTTPS_REGEXP) || []
+function getGitHubPath(remoteUrl /* : string */) {
+  let githubPath;
+  [, githubPath] = remoteUrl.match(MATCH_GH_HTTPS_REGEXP) || [];
   if (githubPath) {
-    return githubPath
+    return githubPath;
   }
-  [ , githubPath ] = remoteUrl.match(MATCH_GH_SSH_REGEXP) || []
+  [, githubPath] = remoteUrl.match(MATCH_GH_SSH_REGEXP) || [];
   if (githubPath) {
-    return githubPath
+    return githubPath;
   }
-  return ''
+  return '';
 }
 
-function getOriginUrl (cwd /* : string */) {
+function getOriginUrl(cwd /* : string */) {
   return execa('git', ['remote', 'get-url', 'origin'], { cwd })
-    .then((result) => result.stdout)
-    .catch(() => '')
+    .then(result => result.stdout)
+    .catch(() => '');
 }
 
-function isGitProject (cwd /* : string */) /* : Promise<boolean> */ {
-  return execa('git', ['status'], { cwd })
-    .then(() => true)
-    .catch(() => false)
+function isGitProject(cwd /* : string */) /* : Promise<boolean> */ {
+  return execa('git', ['status'], { cwd }).then(() => true).catch(() => false);
 }
 
-function init (cwd /* : string */) /* : Promise<any> */ {
-  return isGitProject(cwd)
-    .then((result) => {
-      if (result) {
-        return // already done!
-      }
-      return execa('git', ['init'], { cwd })
-    })
+function init(cwd /* : string */) /* : Promise<any> */ {
+  return isGitProject(cwd).then(result => {
+    if (result) {
+      return; // already done!
+    }
+    return execa('git', ['init'], { cwd });
+  });
 }
 
-function isGitClean (cwd /* : string */) /* : Promise<boolean> */ {
-  return isGitProject(cwd)
-    .then((result) => {
-      if (!result) {
-        return true
-      }
-      // https://github.com/sindresorhus/pure/blob/291574e6/pure.zsh#L253
-      return execa('git', [
-        'status', '--porcelain', '--ignore-submodules', '-unormal'
-      ], { cwd })
-        .then((result) => !(result.stdout || '').trim())
-    })
+function isGitClean(cwd /* : string */) /* : Promise<boolean> */ {
+  return isGitProject(cwd).then(result => {
+    if (!result) {
+      return true;
+    }
+    // https://github.com/sindresorhus/pure/blob/291574e6/pure.zsh#L253
+    return execa(
+      'git',
+      ['status', '--porcelain', '--ignore-submodules', '-unormal'],
+      { cwd }
+    ).then(result => !(result.stdout || '').trim());
+  });
 }
 
-function isPublicGitHub (
+function isPublicGitHub(cwd /* : string */) /* : Promise<boolean> */ {
+  return getOriginUrl(cwd)
+    .then(origin => getGitHubPath(origin))
+    .then(publicPath => !!publicPath);
+}
+
+function isPublicGitHubOrBitbucket(
   cwd /* : string */
 ) /* : Promise<boolean> */ {
   return getOriginUrl(cwd)
-    .then((origin) => getGitHubPath(origin))
-    .then((publicPath) => !!publicPath)
-}
-
-function isPublicGitHubOrBitbucket (
-  cwd /* : string */
-) /* : Promise<boolean> */ {
-  return getOriginUrl(cwd)
-    .then((origin) => getGitHubPath(origin) || getBitbucketPath(origin))
-    .then((publicPath) => !!publicPath)
+    .then(origin => getGitHubPath(origin) || getBitbucketPath(origin))
+    .then(publicPath => !!publicPath);
 }
 
 module.exports = {
@@ -96,4 +91,4 @@ module.exports = {
   isGitProject,
   isPublicGitHub,
   isPublicGitHubOrBitbucket
-}
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,84 +1,90 @@
 /* eslint-disable no-console */
 
 /* @flow */
-'use strict'
+'use strict';
 
-const path = require('path')
+const path = require('path');
 
-const logUpdate = require('log-update')
+const logUpdate = require('log-update');
 
-const fs = require('./fs.js')
-const git = require('./git.js')
-const { getScope } = require('./pkg.js')
-const { loadTasks } = require('./tasks.js')
+const fs = require('./fs.js');
+const git = require('./git.js');
+const { getScope } = require('./pkg.js');
+const { loadTasks } = require('./tasks.js');
 const {
-  TASK_CHECKING, TASK_DONE, TASK_SKIPPED, TASK_WORKING,
+  TASK_CHECKING,
+  TASK_DONE,
+  TASK_SKIPPED,
+  TASK_WORKING,
   TASK_STATUSES
-} = require('./values.js')
+} = require('./values.js');
 
-let projectDir = process.cwd()
-function ensureProjectDir (dir /* : string */) {
+let projectDir = process.cwd();
+function ensureProjectDir(dir /* : string */) {
   if (!dir) {
-    return Promise.resolve()
+    return Promise.resolve();
   }
-  projectDir = path.join(process.cwd(), dir)
-  return fs.mkdir(projectDir)
+  projectDir = path.join(process.cwd(), dir);
+  return fs
+    .mkdir(projectDir)
     .then(() => console.log(`project dir: ${projectDir}`))
-    .catch((err) => {
+    .catch(err => {
       if (err.code === 'EEXIST') {
-        console.error('target directory exists, run from within')
+        console.error('target directory exists, run from within');
       }
-      throw err
-    })
+      throw err;
+    });
 }
 
 /* :: import type { Flags, Task, TaskOptions } from './types.js' */
 
-function runTask (
+function runTask(
   { fn, isNeeded = () => Promise.resolve(true), label } /* : Task */,
   options /* : TaskOptions */
 ) /* : Promise<any> */ {
-  logUpdate(`${label}: ${TASK_STATUSES[TASK_CHECKING]}`)
+  logUpdate(`${label}: ${TASK_STATUSES[TASK_CHECKING]}`);
   return isNeeded(options)
-    .then((needed) => {
+    .then(needed => {
       if (!needed) {
-        logUpdate(`${label}: ${TASK_STATUSES[TASK_SKIPPED]}`)
-        return
+        logUpdate(`${label}: ${TASK_STATUSES[TASK_SKIPPED]}`);
+        return;
       }
-      logUpdate(`${label}: ${TASK_STATUSES[TASK_WORKING]}`)
-      return fn(options)
-        .then(() => logUpdate(`${label}: ${TASK_STATUSES[TASK_DONE]}`))
+      logUpdate(`${label}: ${TASK_STATUSES[TASK_WORKING]}`);
+      return fn(options).then(() =>
+        logUpdate(`${label}: ${TASK_STATUSES[TASK_DONE]}`)
+      );
     })
-    .catch((err) => console.error(label, err))
-    .then(() => logUpdate.done())
+    .catch(err => console.error(label, err))
+    .then(() => logUpdate.done());
 }
 
-function runTasks (tasks /* : Task[] */, options /* : TaskOptions */) {
+function runTasks(tasks /* : Task[] */, options /* : TaskOptions */) {
   return tasks.reduce((prev, task) => {
-    return prev.then(() => runTask(task, options))
-  }, Promise.resolve())
+    return prev.then(() => runTask(task, options));
+  }, Promise.resolve());
 }
 
-function init ([ dir ] /* : string[] */, flags /* : Flags */) {
+function init([dir] /* : string[] */, flags /* : Flags */) {
   ensureProjectDir(dir)
     .then(() => git.isGitClean(projectDir))
-    .then((isGitClean) => {
+    .then(isGitClean => {
       if (!isGitClean && flags.checkGitStatus) {
-        console.error('ERROR: detected un-versioned changes')
-        console.log('specify --no-check-git-status to run anyway')
-        return
+        console.error('ERROR: detected un-versioned changes');
+        console.log('specify --no-check-git-status to run anyway');
+        return;
       }
       return Promise.all([
         getScope(projectDir, flags.scope),
         loadTasks()
-      ])
-      .then(([ scope, tasks ]) => runTasks(tasks, {
-        cwd: projectDir,
-        scope
-      }))
-    })
+      ]).then(([scope, tasks]) =>
+        runTasks(tasks, {
+          cwd: projectDir,
+          scope
+        })
+      );
+    });
 }
 
 module.exports = {
   init
-}
+};

--- a/lib/nodejs-versions.js
+++ b/lib/nodejs-versions.js
@@ -1,52 +1,51 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const fetch = require('node-fetch')
-const pMemoize = require('p-memoize')
-const { major, minSatisfying } = require('semver')
+const fetch = require('node-fetch');
+const pMemoize = require('p-memoize');
+const { major, minSatisfying } = require('semver');
 
 /* :: import type { NodejsVersion } from './types.js' */
 
-function fetchVersions () /* : Promise<NodejsVersion[]> */ {
-  const URL = 'https://nodejs.org/dist/index.json'
-  return fetch(URL)
-    .then((res) => res.json())
-    .catch(() => [])
+function fetchVersions() /* : Promise<NodejsVersion[]> */ {
+  const URL = 'https://nodejs.org/dist/index.json';
+  return fetch(URL).then(res => res.json()).catch(() => []);
 }
 
-function * evenNumbers (min /* : number */, max /* : number */) {
+function* evenNumbers(min /* : number */, max /* : number */) {
   // ensure we're starting with an even number within range
-  let next = Math.ceil(min)
-  next += next % 2 === 0 ? 0 : 1
+  let next = Math.ceil(min);
+  next += next % 2 === 0 ? 0 : 1;
   while (next <= max) {
-    yield next
-    next += 2
+    yield next;
+    next += 2;
   }
 }
 
-function supportedMajors (
+function supportedMajors(
   range /* :? string */,
   versions /* : NodejsVersion[] */
 ) /* : number[] */ {
-  const min = major(minSatisfying(
-    versions.map((version) => version.version),
-    range || process.version
-  ))
-  const max = major(versions.length ? versions[0].version : process.version)
-  const evens = Array.from(evenNumbers(min, max))
+  const min = major(
+    minSatisfying(
+      versions.map(version => version.version),
+      range || process.version
+    )
+  );
+  const max = major(versions.length ? versions[0].version : process.version);
+  const evens = Array.from(evenNumbers(min, max));
   return [
     ...evens,
-    ...(max % 2 === 0 ? [] : [ max ]) // ensure latest is always included
-  ]
+    ...(max % 2 === 0 ? [] : [max]) // ensure latest is always included
+  ];
 }
 
-function fetchSupportedMajors (range /* :? string */) {
-  return fetchVersions()
-    .then((versions) => supportedMajors(range, versions))
+function fetchSupportedMajors(range /* :? string */) {
+  return fetchVersions().then(versions => supportedMajors(range, versions));
 }
 
 module.exports = {
   fetchSupportedMajors: pMemoize(fetchSupportedMajors),
   fetchVersions: pMemoize(fetchVersions),
   supportedMajors
-}
+};

--- a/lib/pkg.js
+++ b/lib/pkg.js
@@ -1,96 +1,96 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const path = require('path')
+const path = require('path');
 
-const loadJson = require('load-json-file')
-const union = require('lodash.union')
-const without = require('lodash.without')
+const loadJson = require('load-json-file');
+const union = require('lodash.union');
+const without = require('lodash.without');
 
-const MATCH_SCOPE_REGEXP = /^@(\w[\w_.-]*)\//
-const SCOPED_REGEXP = /^@(\w[\w_.-]*)\/(\w[\w_.-]*)$/
+const MATCH_SCOPE_REGEXP = /^@(\w[\w_.-]*)\//;
+const SCOPED_REGEXP = /^@(\w[\w_.-]*)\/(\w[\w_.-]*)$/;
 
 /* :: import type { PackageJSON, PackageJSONDependencies } from './types.js' */
 
-function addScript (
+function addScript(
   pkg /* : PackageJSON */,
   name /* : string */,
   value /* : string */
 ) {
-  const scripts = pkg.scripts || {}
+  const scripts = pkg.scripts || {};
 
-  let values = (scripts[name] || '').split(' && ')
-  values = values.filter((v) => !!v) // drop empties
-  values = union(values, [ value ])
-  scripts[name] = values.join(' && ')
+  let values = (scripts[name] || '').split(' && ');
+  values = values.filter(v => !!v); // drop empties
+  values = union(values, [value]);
+  scripts[name] = values.join(' && ');
 
-  pkg.scripts = scripts
+  pkg.scripts = scripts;
 }
 
-function getPkg (cwd /* : string */) /* : Promise<PackageJSON> */ {
-  return loadJson(path.join(cwd, 'package.json'))
-    .catch(() => ({})) // no file? default to new Object
+function getPkg(cwd /* : string */) /* : Promise<PackageJSON> */ {
+  return loadJson(path.join(cwd, 'package.json')).catch(() => ({})); // no file? default to new Object
 }
 
-function getScope (cwd /* : string */, scope /* : string */) {
+function getScope(cwd /* : string */, scope /* : string */) {
   if (scope) {
-    return Promise.resolve(scope.replace(/@/g, ''))
+    return Promise.resolve(scope.replace(/@/g, ''));
   }
-  return getPkg(cwd)
-    .then((pkg) => {
-      if (!pkg.name || typeof pkg.name !== 'string') {
-        return ''
-      }
-      if (!SCOPED_REGEXP.test(pkg.name)) {
-        return ''
-      }
-      const [ , pkgScope ] = pkg.name.match(MATCH_SCOPE_REGEXP) || []
-      return pkgScope
-    })
+  return getPkg(cwd).then(pkg => {
+    if (!pkg.name || typeof pkg.name !== 'string') {
+      return '';
+    }
+    if (!SCOPED_REGEXP.test(pkg.name)) {
+      return '';
+    }
+    const [, pkgScope] = pkg.name.match(MATCH_SCOPE_REGEXP) || [];
+    return pkgScope;
+  });
 }
 
-function injectScope (scope /* : string */, name /* : string */) {
-  const [ , currentScope, currentName ] = name.match(SCOPED_REGEXP) || []
+function injectScope(scope /* : string */, name /* : string */) {
+  const [, currentScope, currentName] = name.match(SCOPED_REGEXP) || [];
   if (currentScope && currentName) {
     if (scope && scope !== currentScope) {
-      return `@${scope}/${currentName}`
+      return `@${scope}/${currentName}`;
     }
-    return name
+    return name;
   }
   if (scope) {
-    return `@${scope}/${name}`
+    return `@${scope}/${name}`;
   }
-  return name
+  return name;
 }
 
-function isReactProject (
-  { dependencies = {}, devDependencies = {}, peerDependencies = {} } /* : PackageJSON */
+function isReactProject(
+  {
+    dependencies = {},
+    devDependencies = {},
+    peerDependencies = {}
+  } /* : PackageJSON */
 ) /* : boolean */ {
-  return !!(
-    dependencies.react ||
+  return !!(dependencies.react ||
     devDependencies.react ||
     devDependencies['react-scripts'] ||
-    peerDependencies.react
-  )
+    peerDependencies.react);
 }
 
-function removeScript (
+function removeScript(
   pkg /* : PackageJSON */,
   name /* : string */,
   value /* : string */
 ) {
-  const scripts = pkg.scripts || {}
+  const scripts = pkg.scripts || {};
 
-  let values = (scripts[name] || '').split(' && ')
-  values = values.filter((pt) => !!pt) // drop empties
-  values = without(values, value)
+  let values = (scripts[name] || '').split(' && ');
+  values = values.filter(pt => !!pt); // drop empties
+  values = without(values, value);
   if (values.length) {
-    scripts[name] = values.join(' && ')
+    scripts[name] = values.join(' && ');
   } else {
-    delete scripts[name]
+    delete scripts[name];
   }
 
-  pkg.scripts = scripts
+  pkg.scripts = scripts;
 }
 
 module.exports = {
@@ -100,4 +100,4 @@ module.exports = {
   injectScope,
   isReactProject,
   removeScript
-}
+};

--- a/lib/skeleton/index.js
+++ b/lib/skeleton/index.js
@@ -1,4 +1,4 @@
 /* @flow */
-'use strict'
+'use strict';
 
-module.exports = {}
+module.exports = {};

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -1,15 +1,15 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const path = require('path')
+const path = require('path');
 
-const intersection = require('lodash.intersection')
+const intersection = require('lodash.intersection');
 
-const fs = require('./fs.js')
+const fs = require('./fs.js');
 
 /* :: import type { Flags, Task, TaskOptions } from './types.js' */
 
-const TASKS_DIR = path.join(__dirname, 'tasks')
+const TASKS_DIR = path.join(__dirname, 'tasks');
 
 /**
 e.g. sequence for resource identifier A:
@@ -18,7 +18,7 @@ e.g. sequence for resource identifier A:
 3. all tasks with "settles: [ A ]" a.k.a. finalises
 */
 
-function compareByMetadata (
+function compareByMetadata(
   { provides: proA = [], requires: reqA = [], settles: setA = [] } /* : Task */,
   { provides: proB = [], requires: reqB = [], settles: setB = [] } /* : Task */
 ) /* : number */ {
@@ -27,36 +27,39 @@ function compareByMetadata (
     intersection(proA, setB).length ||
     intersection(reqA, setB).length
   ) {
-    return -1
+    return -1;
   }
   if (
     intersection(proB, reqA).length ||
     intersection(proB, setA).length ||
     intersection(reqB, setA).length
   ) {
-    return 1
+    return 1;
   }
-  const setDiff = setA.length - setB.length
+  const setDiff = setA.length - setB.length;
   if (Math.abs(setDiff)) {
-    return setDiff
+    return setDiff;
   }
-  const reqDiff = reqA.length - reqB.length
+  const reqDiff = reqA.length - reqB.length;
   if (Math.abs(reqDiff)) {
-    return reqDiff
+    return reqDiff;
   }
-  return 0
+  return 0;
 }
 
-function loadTasks () /* : Promise<Task[]> */ {
-  return fs.readdir(TASKS_DIR)
-    .then((files) => files.map((file) => {
-      // $FlowFixMe: intentionally `require()` a dynamic path here
-      return require(path.join(TASKS_DIR, file))
-    }))
-    .then((tasks) => tasks.sort(compareByMetadata)) // .sort() mutates!
+function loadTasks() /* : Promise<Task[]> */ {
+  return fs
+    .readdir(TASKS_DIR)
+    .then(files =>
+      files.map(file => {
+        // $FlowFixMe: intentionally `require()` a dynamic path here
+        return require(path.join(TASKS_DIR, file));
+      })
+    )
+    .then(tasks => tasks.sort(compareByMetadata)); // .sort() mutates!
 }
 
 module.exports = {
   compareByMetadata,
   loadTasks
-}
+};

--- a/lib/tasks/appveyor.yml.js
+++ b/lib/tasks/appveyor.yml.js
@@ -10,10 +10,7 @@ const without = require('lodash.without')
 
 const { ensureArrayTail } = require('../data.js')
 const fs = require('../fs.js')
-const {
-  getBitbucketPath, getGitHubPath, getOriginUrl,
-  isPublicGitHubOrBitbucket
-} = require('../git.js')
+const { isPublicGitHubOrBitbucket } = require('../git.js')
 const { fetchSupportedMajors } = require('../nodejs-versions.js')
 const { GIT_REPO, PACKAGE_JSON } = require('../values.js')
 
@@ -85,51 +82,47 @@ function updateNodeNpm (cfg /* : Object */) /* : Object */ {
 
 function fn ({ cwd } /* : TaskOptions */) {
   const filePath = path.join(cwd, 'appveyor.yml')
-  return getOriginUrl(cwd)
-    .then((origin) => getGitHubPath(origin) || getBitbucketPath(origin))
-    .then((publicPath) => {
-      return fs.touch(filePath)
-        .then(() => fs.readFile(filePath, 'utf8'))
-        .then((contents) => Promise.all([
-          safeLoad(contents),
-          readPkgUp({ cwd })
-            .then(({ pkg }) => fetchSupportedMajors((pkg.engines || {}).node))
-        ]))
-        .then(([ cfg, majors ]) => {
-          cfg = cfg || {}
-          cfg.build = cfg.build || 'off'
+  return fs.touch(filePath)
+    .then(() => fs.readFile(filePath, 'utf8'))
+    .then((contents) => Promise.all([
+      safeLoad(contents),
+      readPkgUp({ cwd })
+        .then(({ pkg }) => fetchSupportedMajors((pkg.engines || {}).node))
+    ]))
+    .then(([cfg, majors]) => {
+      cfg = cfg || {}
+      cfg.build = cfg.build || 'off'
 
-          cfg.environment = cfg.environment || {}
-          cfg.environment.matrix = cfg.environment.matrix || []
-          majors.forEach((major) => {
-            if (cfg.environment.matrix.every((env) => {
-              return env.nodejs_version !== '' + major
-            })) {
-              cfg.environment.matrix.push({ nodejs_version: '' + major })
-            }
-          })
+      cfg.environment = cfg.environment || {}
+      cfg.environment.matrix = cfg.environment.matrix || []
+      majors.forEach((major) => {
+        if (cfg.environment.matrix.every((env) => {
+          return env.nodejs_version !== '' + major
+        })) {
+          cfg.environment.matrix.push({ nodejs_version: '' + major })
+        }
+      })
 
-          cfg = updateNodeNpm(cfg)
+      cfg = updateNodeNpm(cfg)
 
-          cfg.install = ensureArrayTail(cfg.install, 'npm install')
+      cfg.install = ensureArrayTail(cfg.install, 'npm install')
 
-          cfg.test_script = cfg.test_script || []
-          cfg.test_script = union(cfg.test_script, [
-            'node --version',
-            'npm --version',
-            'npm test'
-          ])
+      cfg.test_script = cfg.test_script || []
+      cfg.test_script = union(cfg.test_script, [
+        'node --version',
+        'npm --version',
+        'npm test'
+      ])
 
-          // anything to do with npm's cache is likely to cause EPERMs
-          cfg.test_script = without(cfg.test_script, 'npm cache clean')
+      // anything to do with npm's cache is likely to cause EPERMs
+      cfg.test_script = without(cfg.test_script, 'npm cache clean')
 
-          cfg = pruneInstall(cfg)
-          cfg = pruneCache(cfg)
+      cfg = pruneInstall(cfg)
+      cfg = pruneCache(cfg)
 
-          return safeDump(cfg)
-        })
-        .then((data) => fs.writeFile(filePath, data))
+      return safeDump(cfg)
     })
+    .then((data) => fs.writeFile(filePath, data))
 }
 
 function isNeeded ({ cwd } /* : TaskOptions */) {

--- a/lib/tasks/appveyor.yml.js
+++ b/lib/tasks/appveyor.yml.js
@@ -1,133 +1,138 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const path = require('path')
+const path = require('path');
 
-const { safeDump, safeLoad } = require('js-yaml')
-const readPkgUp = require('read-pkg-up')
-const union = require('lodash.union')
-const without = require('lodash.without')
+const { safeDump, safeLoad } = require('js-yaml');
+const readPkgUp = require('read-pkg-up');
+const union = require('lodash.union');
+const without = require('lodash.without');
 
-const { ensureArrayTail } = require('../data.js')
-const fs = require('../fs.js')
-const { isPublicGitHubOrBitbucket } = require('../git.js')
-const { fetchSupportedMajors } = require('../nodejs-versions.js')
-const { GIT_REPO, PACKAGE_JSON } = require('../values.js')
+const { ensureArrayTail } = require('../data.js');
+const fs = require('../fs.js');
+const { isPublicGitHubOrBitbucket } = require('../git.js');
+const { fetchSupportedMajors } = require('../nodejs-versions.js');
+const { GIT_REPO, PACKAGE_JSON } = require('../values.js');
 
-const LABEL = 'appveyor.yml initialised'
+const LABEL = 'appveyor.yml initialised';
 
 /* :: import type { TaskOptions } from '../types.js' */
 
-function pruneCache (cfg /* : Object */) /* : Object */ {
+function pruneCache(cfg /* : Object */) /* : Object */ {
   // anything to do with npm's cache is likely to cause EPERMs
-  cfg.cache = without(cfg.cache || [], 'node_modules')
+  cfg.cache = without(cfg.cache || [], 'node_modules');
 
   // remove completely if empty
   if (!cfg.cache.length) {
-    delete cfg.cache
+    delete cfg.cache;
   }
 
-  return cfg
+  return cfg;
 }
 
-function pruneInstall (cfg /* : Object */) /* : Object */ {
+function pruneInstall(cfg /* : Object */) /* : Object */ {
   // was never a good idea to install types definitions on-the-fly
   cfg.install = without(
     cfg.install || [],
     'npm install --global npm',
     'npm install --global flow-typed',
     'npm install --global typings'
-  )
+  );
 
   // anything to do with npm's cache is likely to cause EPERMs
-  cfg.install = without(
-    cfg.install || [],
-    'npm cache clean'
-  )
+  cfg.install = without(cfg.install || [], 'npm cache clean');
 
   // remove completely if empty
   if (!cfg.install.length) {
-    delete cfg.install
+    delete cfg.install;
   }
 
-  return cfg
+  return cfg;
 }
 
-function updateNodeNpm (cfg /* : Object */) /* : Object */ {
+function updateNodeNpm(cfg /* : Object */) /* : Object */ {
   // fix any non-64-bit Node.js install steps
-  cfg.install = (cfg.install || []).map((step) => {
+  cfg.install = (cfg.install || []).map(step => {
     if (step.ps === 'Install-Product node $env:nodejs_version') {
       return {
         ps: 'Install-Product node $env:nodejs_version x64'
-      }
+      };
     }
-    return step
-  })
+    return step;
+  });
 
   // ensure 64-bit Node.js version from matrix is installed
-  if (cfg.install.every((step) => {
-    return step.ps !== 'Install-Product node $env:nodejs_version x64'
-  })) {
-    cfg.install.unshift({ ps: 'Install-Product node $env:nodejs_version x64' })
+  if (
+    cfg.install.every(step => {
+      return step.ps !== 'Install-Product node $env:nodejs_version x64';
+    })
+  ) {
+    cfg.install.unshift({ ps: 'Install-Product node $env:nodejs_version x64' });
   }
 
   cfg.install = union(cfg.install || [], [
     'npm install --global npm-windows-upgrade',
     'npm-windows-upgrade --no-spinner --npm-version latest',
     'npm install --global yarn'
-  ])
+  ]);
 
-  return cfg
+  return cfg;
 }
 
-function fn ({ cwd } /* : TaskOptions */) {
-  const filePath = path.join(cwd, 'appveyor.yml')
-  return fs.touch(filePath)
+function fn({ cwd } /* : TaskOptions */) {
+  const filePath = path.join(cwd, 'appveyor.yml');
+  return fs
+    .touch(filePath)
     .then(() => fs.readFile(filePath, 'utf8'))
-    .then((contents) => Promise.all([
-      safeLoad(contents),
-      readPkgUp({ cwd })
-        .then(({ pkg }) => fetchSupportedMajors((pkg.engines || {}).node))
-    ]))
+    .then(contents =>
+      Promise.all([
+        safeLoad(contents),
+        readPkgUp({ cwd }).then(({ pkg }) =>
+          fetchSupportedMajors((pkg.engines || {}).node)
+        )
+      ])
+    )
     .then(([cfg, majors]) => {
-      cfg = cfg || {}
-      cfg.build = cfg.build || 'off'
+      cfg = cfg || {};
+      cfg.build = cfg.build || 'off';
 
-      cfg.environment = cfg.environment || {}
-      cfg.environment.matrix = cfg.environment.matrix || []
-      majors.forEach((major) => {
-        if (cfg.environment.matrix.every((env) => {
-          return env.nodejs_version !== '' + major
-        })) {
-          cfg.environment.matrix.push({ nodejs_version: '' + major })
+      cfg.environment = cfg.environment || {};
+      cfg.environment.matrix = cfg.environment.matrix || [];
+      majors.forEach(major => {
+        if (
+          cfg.environment.matrix.every(env => {
+            return env.nodejs_version !== '' + major;
+          })
+        ) {
+          cfg.environment.matrix.push({ nodejs_version: '' + major });
         }
-      })
+      });
 
-      cfg = updateNodeNpm(cfg)
+      cfg = updateNodeNpm(cfg);
 
-      cfg.install = ensureArrayTail(cfg.install, 'npm install')
+      cfg.install = ensureArrayTail(cfg.install, 'npm install');
 
-      cfg.test_script = cfg.test_script || []
+      cfg.test_script = cfg.test_script || [];
       cfg.test_script = union(cfg.test_script, [
         'node --version',
         'npm --version',
         'npm test'
-      ])
+      ]);
 
       // anything to do with npm's cache is likely to cause EPERMs
-      cfg.test_script = without(cfg.test_script, 'npm cache clean')
+      cfg.test_script = without(cfg.test_script, 'npm cache clean');
 
-      cfg = pruneInstall(cfg)
-      cfg = pruneCache(cfg)
+      cfg = pruneInstall(cfg);
+      cfg = pruneCache(cfg);
 
-      return safeDump(cfg)
+      return safeDump(cfg);
     })
-    .then((data) => fs.writeFile(filePath, data))
+    .then(data => fs.writeFile(filePath, data));
 }
 
-function isNeeded ({ cwd } /* : TaskOptions */) {
+function isNeeded({ cwd } /* : TaskOptions */) {
   // free AppVeyor requires public GitHub / Bitbucket hosting
-  return isPublicGitHubOrBitbucket(cwd)
+  return isPublicGitHubOrBitbucket(cwd);
 }
 
 module.exports = {
@@ -135,5 +140,5 @@ module.exports = {
   id: path.basename(__filename),
   isNeeded,
   label: LABEL,
-  requires: [ GIT_REPO, PACKAGE_JSON ]
-}
+  requires: [GIT_REPO, PACKAGE_JSON]
+};

--- a/lib/tasks/badge-appveyor.js
+++ b/lib/tasks/badge-appveyor.js
@@ -1,68 +1,75 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const os = require('os')
-const path = require('path')
+const os = require('os');
+const path = require('path');
 
-const through2 = require('through2')
-const vfs = require('vinyl-fs')
+const through2 = require('through2');
+const vfs = require('vinyl-fs');
 
-const fs = require('../fs.js')
+const fs = require('../fs.js');
 const {
-  getBitbucketPath, getGitHubPath, getOriginUrl,
+  getBitbucketPath,
+  getGitHubPath,
+  getOriginUrl,
   isPublicGitHubOrBitbucket
-} = require('../git.js')
-const { GIT_REPO, PACKAGE_JSON } = require('../values.js')
+} = require('../git.js');
+const { GIT_REPO, PACKAGE_JSON } = require('../values.js');
 
-const LABEL = 'AppVeyor badge in README.md'
+const LABEL = 'AppVeyor badge in README.md';
 
 /* :: import type { TaskOptions } from '../types.js' */
 
-function fn ({ cwd } /* : TaskOptions */) {
+function fn({ cwd } /* : TaskOptions */) {
   return Promise.all([
     getOriginUrl(cwd),
     fs.touch(path.join(cwd, 'README.md'))
-  ])
-    .then(([ remoteUrl ]) => new Promise((resolve, reject) => {
-      let hosting
-      let publicPath
-      publicPath = getBitbucketPath(remoteUrl)
-      if (publicPath) {
-        hosting = 'bitbucket'
-      } else {
-        publicPath = getGitHubPath(remoteUrl)
+  ]).then(
+    ([remoteUrl]) =>
+      new Promise((resolve, reject) => {
+        let hosting;
+        let publicPath;
+        publicPath = getBitbucketPath(remoteUrl);
         if (publicPath) {
-          hosting = 'github'
-        }
-      }
-      if (!hosting || !publicPath) {
-        resolve()
-        return // free AppVeyor requires public git hosting
-      }
-      publicPath = publicPath.replace(/\./g, '-')
-      vfs.src('README.md', { cwd })
-        .pipe(through2.obj((file, enc, cb) => {
-          const svgUrl = `https://img.shields.io/appveyor/ci/${publicPath}/master.svg`
-          const projectUrl = `https://ci.appveyor.com/project/${publicPath}`
-          const mdBadge = `[![AppVeyor Status](${svgUrl})](${projectUrl})`
-          let contents = file.contents.toString(enc)
-          if (!contents.includes(`(${projectUrl})`)) {
-            const lines = contents.split(os.EOL)
-            lines[0] += ` ${mdBadge}`
-            contents = lines.join(os.EOL)
+          hosting = 'bitbucket';
+        } else {
+          publicPath = getGitHubPath(remoteUrl);
+          if (publicPath) {
+            hosting = 'github';
           }
-          file.contents = Buffer.from(contents, enc)
-          cb(null, file)
-        }))
-        .pipe(vfs.dest(cwd))
-        .on('error', (err) => reject(err))
-        .on('end', () => resolve())
-    }))
+        }
+        if (!hosting || !publicPath) {
+          resolve();
+          return; // free AppVeyor requires public git hosting
+        }
+        publicPath = publicPath.replace(/\./g, '-');
+        vfs
+          .src('README.md', { cwd })
+          .pipe(
+            through2.obj((file, enc, cb) => {
+              const svgUrl = `https://img.shields.io/appveyor/ci/${publicPath}/master.svg`;
+              const projectUrl = `https://ci.appveyor.com/project/${publicPath}`;
+              const mdBadge = `[![AppVeyor Status](${svgUrl})](${projectUrl})`;
+              let contents = file.contents.toString(enc);
+              if (!contents.includes(`(${projectUrl})`)) {
+                const lines = contents.split(os.EOL);
+                lines[0] += ` ${mdBadge}`;
+                contents = lines.join(os.EOL);
+              }
+              file.contents = Buffer.from(contents, enc);
+              cb(null, file);
+            })
+          )
+          .pipe(vfs.dest(cwd))
+          .on('error', err => reject(err))
+          .on('end', () => resolve());
+      })
+  );
 }
 
-function isNeeded ({ cwd } /* : TaskOptions */) {
+function isNeeded({ cwd } /* : TaskOptions */) {
   // free AppVeyor requires public GitHub / Bitbucket hosting
-  return isPublicGitHubOrBitbucket(cwd)
+  return isPublicGitHubOrBitbucket(cwd);
 }
 
 module.exports = {
@@ -70,5 +77,5 @@ module.exports = {
   id: path.basename(__filename),
   isNeeded,
   label: LABEL,
-  requires: [ GIT_REPO, PACKAGE_JSON ]
-}
+  requires: [GIT_REPO, PACKAGE_JSON]
+};

--- a/lib/tasks/badge-npm.js
+++ b/lib/tasks/badge-npm.js
@@ -1,48 +1,53 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const os = require('os')
-const path = require('path')
+const os = require('os');
+const path = require('path');
 
-const through2 = require('through2')
-const vfs = require('vinyl-fs')
+const through2 = require('through2');
+const vfs = require('vinyl-fs');
 
-const fs = require('../fs.js')
-const { getPkg } = require('../pkg.js')
-const { PACKAGE_JSON, PACKAGE_JSON_NAME } = require('../values.js')
+const fs = require('../fs.js');
+const { getPkg } = require('../pkg.js');
+const { PACKAGE_JSON, PACKAGE_JSON_NAME } = require('../values.js');
 
-const LABEL = 'NPM version badge in README.md'
+const LABEL = 'NPM version badge in README.md';
 
 /* :: import type { TaskOptions } from '../types.js' */
 
-function fn ({ cwd } /* : TaskOptions */) {
+function fn({ cwd } /* : TaskOptions */) {
   return Promise.all([
     getPkg(cwd).then(({ name }) => name),
     fs.touch(path.join(cwd, 'README.md'))
-  ])
-    .then(([ pkgName ]) => new Promise((resolve, reject) => {
-      vfs.src('README.md', { cwd })
-        .pipe(through2.obj((file, enc, cb) => {
-          const svgUrl = `https://img.shields.io/npm/v/${pkgName}.svg`
-          const mdBadge = `[![npm](${svgUrl}?maxAge=2592000)](https://www.npmjs.com/package/${pkgName})`
-          let contents = file.contents.toString(enc)
-          if (!contents.includes(svgUrl)) {
-            const lines = contents.split(os.EOL)
-            lines[0] += ` ${mdBadge}`
-            contents = lines.join(os.EOL)
-          }
-          file.contents = Buffer.from(contents, enc)
-          cb(null, file)
-        }))
-        .pipe(vfs.dest(cwd))
-        .on('error', (err) => reject(err))
-        .on('end', () => resolve())
-    }))
+  ]).then(
+    ([pkgName]) =>
+      new Promise((resolve, reject) => {
+        vfs
+          .src('README.md', { cwd })
+          .pipe(
+            through2.obj((file, enc, cb) => {
+              const svgUrl = `https://img.shields.io/npm/v/${pkgName}.svg`;
+              const mdBadge = `[![npm](${svgUrl}?maxAge=2592000)](https://www.npmjs.com/package/${pkgName})`;
+              let contents = file.contents.toString(enc);
+              if (!contents.includes(svgUrl)) {
+                const lines = contents.split(os.EOL);
+                lines[0] += ` ${mdBadge}`;
+                contents = lines.join(os.EOL);
+              }
+              file.contents = Buffer.from(contents, enc);
+              cb(null, file);
+            })
+          )
+          .pipe(vfs.dest(cwd))
+          .on('error', err => reject(err))
+          .on('end', () => resolve());
+      })
+  );
 }
 
-function isNeeded ({ cwd } /* : TaskOptions */) {
+function isNeeded({ cwd } /* : TaskOptions */) {
   // private packages should not get an NPM badge
-  return getPkg(cwd).then((pkg) => !pkg['private'])
+  return getPkg(cwd).then(pkg => !pkg['private']);
 }
 
 module.exports = {
@@ -50,5 +55,5 @@ module.exports = {
   id: path.basename(__filename),
   isNeeded,
   label: LABEL,
-  requires: [ PACKAGE_JSON, PACKAGE_JSON_NAME ]
-}
+  requires: [PACKAGE_JSON, PACKAGE_JSON_NAME]
+};

--- a/lib/tasks/badge-travis.js
+++ b/lib/tasks/badge-travis.js
@@ -1,50 +1,53 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const os = require('os')
-const path = require('path')
+const os = require('os');
+const path = require('path');
 
-const through2 = require('through2')
-const vfs = require('vinyl-fs')
+const through2 = require('through2');
+const vfs = require('vinyl-fs');
 
-const fs = require('../fs.js')
-const {
-  getGitHubPath, getOriginUrl, isPublicGitHub
-} = require('../git.js')
-const { GIT_REPO, PACKAGE_JSON } = require('../values.js')
+const fs = require('../fs.js');
+const { getGitHubPath, getOriginUrl, isPublicGitHub } = require('../git.js');
+const { GIT_REPO, PACKAGE_JSON } = require('../values.js');
 
-const LABEL = 'Travis CI badge in README.md'
+const LABEL = 'Travis CI badge in README.md';
 
 /* :: import type { TaskOptions } from '../types.js' */
 
-function fn ({ cwd } /* : TaskOptions */) {
+function fn({ cwd } /* : TaskOptions */) {
   return Promise.all([
     getOriginUrl(cwd).then(getGitHubPath),
     fs.touch(path.join(cwd, 'README.md'))
-  ])
-    .then(([ githubPath ]) => new Promise((resolve, reject) => {
-      vfs.src('README.md', { cwd })
-        .pipe(through2.obj((file, enc, cb) => {
-          const svgUrl = `https://travis-ci.org/${githubPath}.svg?branch=master`
-          const mdBadge = `[![Travis CI Status](${svgUrl})](https://travis-ci.org/${githubPath})`
-          let contents = file.contents.toString(enc)
-          if (!contents.includes(svgUrl)) {
-            const lines = contents.split(os.EOL)
-            lines[0] += ` ${mdBadge}`
-            contents = lines.join(os.EOL)
-          }
-          file.contents = Buffer.from(contents, enc)
-          cb(null, file)
-        }))
-        .pipe(vfs.dest(cwd))
-        .on('error', (err) => reject(err))
-        .on('end', () => resolve())
-    }))
+  ]).then(
+    ([githubPath]) =>
+      new Promise((resolve, reject) => {
+        vfs
+          .src('README.md', { cwd })
+          .pipe(
+            through2.obj((file, enc, cb) => {
+              const svgUrl = `https://travis-ci.org/${githubPath}.svg?branch=master`;
+              const mdBadge = `[![Travis CI Status](${svgUrl})](https://travis-ci.org/${githubPath})`;
+              let contents = file.contents.toString(enc);
+              if (!contents.includes(svgUrl)) {
+                const lines = contents.split(os.EOL);
+                lines[0] += ` ${mdBadge}`;
+                contents = lines.join(os.EOL);
+              }
+              file.contents = Buffer.from(contents, enc);
+              cb(null, file);
+            })
+          )
+          .pipe(vfs.dest(cwd))
+          .on('error', err => reject(err))
+          .on('end', () => resolve());
+      })
+  );
 }
 
-function isNeeded ({ cwd } /* : TaskOptions */) {
+function isNeeded({ cwd } /* : TaskOptions */) {
   // free Travis CI requires public GitHub hosting
-  return isPublicGitHub(cwd)
+  return isPublicGitHub(cwd);
 }
 
 module.exports = {
@@ -52,5 +55,5 @@ module.exports = {
   id: path.basename(__filename),
   isNeeded,
   label: LABEL,
-  requires: [ GIT_REPO, PACKAGE_JSON ]
-}
+  requires: [GIT_REPO, PACKAGE_JSON]
+};

--- a/lib/tasks/editorconfig.js
+++ b/lib/tasks/editorconfig.js
@@ -1,27 +1,28 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const path = require('path')
+const path = require('path');
 
-const fetch = require('node-fetch')
+const fetch = require('node-fetch');
 
-const fs = require('../fs.js')
+const fs = require('../fs.js');
 
-const LABEL = '.editorconfig initialised'
+const LABEL = '.editorconfig initialised';
 
-const STANDARD_URL = 'https://raw.githubusercontent.com/jokeyrhyme/standard-editorconfig/master/.editorconfig'
+const STANDARD_URL =
+  'https://raw.githubusercontent.com/jokeyrhyme/standard-editorconfig/master/.editorconfig';
 
 /* :: import type { TaskOptions } from '../types.js' */
 
-function fn ({ cwd } /* : TaskOptions */) {
-  const filePath = path.join(cwd, '.editorconfig')
+function fn({ cwd } /* : TaskOptions */) {
+  const filePath = path.join(cwd, '.editorconfig');
   return fetch(STANDARD_URL)
-    .then((res) => res.text())
-    .then((data) => fs.writeFile(filePath, data))
+    .then(res => res.text())
+    .then(data => fs.writeFile(filePath, data));
 }
 
 module.exports = {
   fn,
   id: path.basename(__filename),
   label: LABEL
-}
+};

--- a/lib/tasks/eslint.js
+++ b/lib/tasks/eslint.js
@@ -15,15 +15,12 @@ const LABEL = 'ESLint installed and configured'
 
 const ESLINT_PACKAGES = [
   'eslint',
-  'eslint-config-standard',
   'eslint-plugin-import',
   'eslint-plugin-node',
-  'eslint-plugin-promise',
-  'eslint-plugin-standard'
+  'eslint-plugin-promise'
 ]
 
 const ESLINT_REACT_PACKAGES = [
-  'eslint-config-standard-react',
   'eslint-plugin-react'
 ]
 
@@ -52,10 +49,26 @@ function npmScript (cwd) {
   }, JSON_OPTIONS)
 }
 
+function npmUninstall (cwd) {
+  const standardStylePackages = [
+    'eslint-config-semistandard',
+    'eslint-config-standard',
+    'eslint-config-standard-jsx',
+    'eslint-config-standard-react',
+    'eslint-plugin-standard'
+  ]
+
+  return execa('npm', [
+    'uninstall', '--save-dev',
+    ...standardStylePackages
+  ], { cwd })
+}
+
 /* :: import type { TaskOptions } from '../types.js' */
 
 function fn ({ cwd } /* : TaskOptions */) {
-  return npmInstall(cwd)
+  return npmUninstall(cwd)
+    .then(() => npmInstall(cwd))
     .then(() => npmScript(cwd))
 }
 

--- a/lib/tasks/eslint.js
+++ b/lib/tasks/eslint.js
@@ -1,81 +1,80 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const path = require('path')
+const path = require('path');
 
-const execa = require('execa')
-const updateJsonFile = require('update-json-file')
+const execa = require('execa');
+const updateJsonFile = require('update-json-file');
 
-const { getPkg, isReactProject } = require('../pkg.js')
+const { getPkg, isReactProject } = require('../pkg.js');
 const {
-  JSON_OPTIONS, PACKAGE_JSON, PACKAGE_JSON_DEVDEPS
-} = require('../values.js')
+  JSON_OPTIONS,
+  PACKAGE_JSON,
+  PACKAGE_JSON_DEVDEPS
+} = require('../values.js');
 
-const LABEL = 'ESLint installed and configured'
+const LABEL = 'ESLint installed and configured';
 
 const ESLINT_PACKAGES = [
   'eslint',
   'eslint-plugin-import',
   'eslint-plugin-node',
   'eslint-plugin-promise'
-]
+];
 
-const ESLINT_REACT_PACKAGES = [
-  'eslint-plugin-react'
-]
+const ESLINT_REACT_PACKAGES = ['eslint-plugin-react'];
 
-function npmInstall (cwd) {
-  return getPkg(cwd)
-    .then((pkg) => {
-      let packages = [].concat(ESLINT_PACKAGES)
-      if (isReactProject(pkg)) {
-        packages = packages.concat(ESLINT_REACT_PACKAGES)
-      }
-      const devDeps = Object.keys(pkg.devDependencies || {})
-      if (!packages.every((name) => devDeps.includes(name))) {
-        return execa('npm', [
-          'install', '--save-dev',
-          ...packages
-        ], { cwd })
-      }
-    })
+function npmInstall(cwd) {
+  return getPkg(cwd).then(pkg => {
+    let packages = [].concat(ESLINT_PACKAGES);
+    if (isReactProject(pkg)) {
+      packages = packages.concat(ESLINT_REACT_PACKAGES);
+    }
+    const devDeps = Object.keys(pkg.devDependencies || {});
+    if (!packages.every(name => devDeps.includes(name))) {
+      return execa('npm', ['install', '--save-dev', ...packages], { cwd });
+    }
+  });
 }
 
-function npmScript (cwd) {
-  return updateJsonFile(path.join(cwd, 'package.json'), (pkg) => {
-    pkg.scripts = pkg.scripts || {}
-    pkg.scripts.eslint = 'eslint --fix --cache .'
-    return pkg
-  }, JSON_OPTIONS)
+function npmScript(cwd) {
+  return updateJsonFile(
+    path.join(cwd, 'package.json'),
+    pkg => {
+      pkg.scripts = pkg.scripts || {};
+      pkg.scripts.eslint = 'eslint --fix --cache .';
+      return pkg;
+    },
+    JSON_OPTIONS
+  );
 }
 
-function npmUninstall (cwd) {
+function npmUninstall(cwd) {
   const standardStylePackages = [
     'eslint-config-semistandard',
     'eslint-config-standard',
     'eslint-config-standard-jsx',
     'eslint-config-standard-react',
     'eslint-plugin-standard'
-  ]
+  ];
 
-  return execa('npm', [
-    'uninstall', '--save-dev',
-    ...standardStylePackages
-  ], { cwd })
+  return execa('npm', ['uninstall', '--save-dev', ...standardStylePackages], {
+    cwd
+  });
 }
 
 /* :: import type { TaskOptions } from '../types.js' */
 
-function fn ({ cwd } /* : TaskOptions */) {
+function fn({ cwd } /* : TaskOptions */) {
   return npmUninstall(cwd)
     .then(() => npmInstall(cwd))
-    .then(() => npmScript(cwd))
+    .then(() => npmScript(cwd));
 }
 
 module.exports = {
   fn,
   id: path.basename(__filename),
   label: LABEL,
-  provides: [ PACKAGE_JSON_DEVDEPS ],
-  requires: [ PACKAGE_JSON ]
-}
+  provides: [PACKAGE_JSON_DEVDEPS],
+  requires: [PACKAGE_JSON]
+};

--- a/lib/tasks/eslintrc.json.js
+++ b/lib/tasks/eslintrc.json.js
@@ -1,22 +1,22 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const path = require('path')
+const path = require('path');
 
-const { mkdir } = require('idempotent-fs')
-const locatePath = require('locate-path')
-const union = require('lodash.union')
-const updateJsonFile = require('update-json-file')
-const without = require('lodash.without')
+const { mkdir } = require('idempotent-fs');
+const locatePath = require('locate-path');
+const union = require('lodash.union');
+const updateJsonFile = require('update-json-file');
+const without = require('lodash.without');
 
-const { getPkg, isReactProject } = require('../pkg.js')
-const { JSON_OPTIONS, PACKAGE_JSON } = require('../values.js')
+const { getPkg, isReactProject } = require('../pkg.js');
+const { JSON_OPTIONS, PACKAGE_JSON } = require('../values.js');
 
-const LABEL = 'ESLint configured'
+const LABEL = 'ESLint configured';
 
-function isNotExplicitInheritance (extend /* : any */) {
+function isNotExplicitInheritance(extend /* : any */) {
   // e.g. [ '../.eslintrc.json' ]
-  return typeof extend === 'string' && extend.indexOf('../') !== 0
+  return typeof extend === 'string' && extend.indexOf('../') !== 0;
 }
 
 /* ::
@@ -25,13 +25,10 @@ type Options = {
 }
 */
 
-function eslintrcUpdater (
-  rc /* : Object */,
-  { hasReact } /* : Options */
-) {
-  rc.extends = rc.extends || []
+function eslintrcUpdater(rc /* : Object */, { hasReact } /* : Options */) {
+  rc.extends = rc.extends || [];
   if (!Array.isArray(rc.extends)) {
-    rc.extends = rc.extends || [ rc.extends ]
+    rc.extends = rc.extends || [rc.extends];
   }
 
   rc.extends = without(
@@ -40,50 +37,48 @@ function eslintrcUpdater (
     'standard',
     'standard-jsx',
     'standard-react'
-  )
+  );
 
   rc.extends = union(rc.extends, [
     'eslint:recommended',
     'plugin:node/recommended'
-  ])
+  ]);
 
-  rc.plugins = rc.plugins || []
-  rc.plugins = union(rc.plugins, [ 'import', 'node', 'promise' ])
+  rc.plugins = rc.plugins || [];
+  rc.plugins = union(rc.plugins, ['import', 'node', 'promise']);
 
   if (hasReact) {
-    rc.extends = union(rc.extends, [ 'plugin:react/recommended' ])
-    rc.plugins = union(rc.plugins, [ 'react' ])
+    rc.extends = union(rc.extends, ['plugin:react/recommended']);
+    rc.plugins = union(rc.plugins, ['react']);
   }
 
-  return rc
+  return rc;
 }
 
-function testEslintrcUpdater (
-  rc /* : Object */
-) {
-  rc.extends = rc.extends || []
+function testEslintrcUpdater(rc /* : Object */) {
+  rc.extends = rc.extends || [];
   if (!Array.isArray(rc.extends)) {
-    rc.extends = rc.extends || [ rc.extends ]
+    rc.extends = rc.extends || [rc.extends];
   }
 
   // no explicit inheritance / extends
-  rc.extends = rc.extends.filter(isNotExplicitInheritance)
+  rc.extends = rc.extends.filter(isNotExplicitInheritance);
   if (!rc.extends.length) {
-    delete rc.extends
+    delete rc.extends;
   }
 
-  rc.rules = rc.rules || {}
+  rc.rules = rc.rules || {};
   // https://github.com/mysticatea/eslint-plugin-node/issues/47
-  rc.rules['node/no-unpublished-require'] = 0
+  rc.rules['node/no-unpublished-require'] = 0;
 
-  return rc
+  return rc;
 }
 
-function eslintrc (cwd) {
+function eslintrc(cwd) {
   const rcPaths = [
     path.join(cwd, '.eslintrc'),
     path.join(cwd, '.eslintrc.json')
-  ]
+  ];
   const testRcPaths = [
     path.join(cwd, 'test', '.eslintrc'),
     path.join(cwd, 'test', '.eslintrc.json'),
@@ -91,31 +86,31 @@ function eslintrc (cwd) {
     path.join(cwd, 'tests', '.eslintrc.json'),
     path.join(cwd, '__tests__', '.eslintrc'),
     path.join(cwd, '__tests__', '.eslintrc.json')
-  ]
-  let hasReact = false
+  ];
+  let hasReact = false;
   return getPkg(cwd)
-    .then((pkg) => {
-      hasReact = isReactProject(pkg)
+    .then(pkg => {
+      hasReact = isReactProject(pkg);
     })
     .then(() => locatePath(rcPaths))
-    .then((cfgPath = rcPaths[1]) => updateJsonFile(
-      cfgPath,
-      (rc) => eslintrcUpdater(rc, { hasReact }),
-      JSON_OPTIONS
-    ))
+    .then((cfgPath = rcPaths[1]) =>
+      updateJsonFile(
+        cfgPath,
+        rc => eslintrcUpdater(rc, { hasReact }),
+        JSON_OPTIONS
+      )
+    )
     .then(() => mkdir(path.join(cwd, 'test')))
     .then(() => locatePath(testRcPaths))
-    .then((cfgPath = testRcPaths[1]) => updateJsonFile(
-      cfgPath,
-      (rc) => testEslintrcUpdater(rc),
-      JSON_OPTIONS
-    ))
+    .then((cfgPath = testRcPaths[1]) =>
+      updateJsonFile(cfgPath, rc => testEslintrcUpdater(rc), JSON_OPTIONS)
+    );
 }
 
 /* :: import type { TaskOptions } from '../types.js' */
 
-function fn ({ cwd } /* : TaskOptions */) {
-  return eslintrc(cwd)
+function fn({ cwd } /* : TaskOptions */) {
+  return eslintrc(cwd);
 }
 
 module.exports = {
@@ -126,5 +121,5 @@ module.exports = {
     eslintrcUpdater,
     testEslintrcUpdater
   },
-  requires: [ PACKAGE_JSON ]
-}
+  requires: [PACKAGE_JSON]
+};

--- a/lib/tasks/eslintrc.json.js
+++ b/lib/tasks/eslintrc.json.js
@@ -51,6 +51,7 @@ function eslintrcUpdater (
   rc.plugins = union(rc.plugins, [ 'import', 'node', 'promise' ])
 
   if (hasReact) {
+    rc.extends = union(rc.extends, [ 'plugin:react/recommended' ])
     rc.plugins = union(rc.plugins, [ 'react' ])
   }
 

--- a/lib/tasks/eslintrc.json.js
+++ b/lib/tasks/eslintrc.json.js
@@ -7,8 +7,8 @@ const { mkdir } = require('idempotent-fs')
 const locatePath = require('locate-path')
 const union = require('lodash.union')
 const updateJsonFile = require('update-json-file')
+const without = require('lodash.without')
 
-const { ensureArrayHead } = require('../data.js')
 const { getPkg, isReactProject } = require('../pkg.js')
 const { JSON_OPTIONS, PACKAGE_JSON } = require('../values.js')
 
@@ -33,24 +33,32 @@ function eslintrcUpdater (
   if (!Array.isArray(rc.extends)) {
     rc.extends = rc.extends || [ rc.extends ]
   }
-  if (hasReact && !rc.extends.includes('standard-react')) {
-    rc.extends = ensureArrayHead(rc.extends, 'standard-react')
-  }
-  if (!rc.extends.includes('semistandard')) {
-    rc.extends = ensureArrayHead(rc.extends, 'standard')
-  }
-  rc.extends = ensureArrayHead(rc.extends, 'plugin:node/recommended')
-  rc.extends = ensureArrayHead(rc.extends, 'eslint:recommended')
+
+  rc.extends = without(
+    rc.extends,
+    'semistandard',
+    'standard',
+    'standard-jsx',
+    'standard-react'
+  )
+
+  rc.extends = union(rc.extends, [
+    'eslint:recommended',
+    'plugin:node/recommended'
+  ])
 
   rc.plugins = rc.plugins || []
-  rc.plugins = union(rc.plugins, [ 'node' ])
+  rc.plugins = union(rc.plugins, [ 'import', 'node', 'promise' ])
+
+  if (hasReact) {
+    rc.plugins = union(rc.plugins, [ 'react' ])
+  }
 
   return rc
 }
 
 function testEslintrcUpdater (
-  rc /* : Object */,
-  { hasReact } /* : Options */
+  rc /* : Object */
 ) {
   rc.extends = rc.extends || []
   if (!Array.isArray(rc.extends)) {
@@ -98,7 +106,7 @@ function eslintrc (cwd) {
     .then(() => locatePath(testRcPaths))
     .then((cfgPath = testRcPaths[1]) => updateJsonFile(
       cfgPath,
-      (rc) => testEslintrcUpdater(rc, { hasReact }),
+      (rc) => testEslintrcUpdater(rc),
       JSON_OPTIONS
     ))
 }

--- a/lib/tasks/fixpack.js
+++ b/lib/tasks/fixpack.js
@@ -1,48 +1,50 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const path = require('path')
+const path = require('path');
 
-const execa = require('execa')
-const updateJsonFile = require('update-json-file')
+const execa = require('execa');
+const updateJsonFile = require('update-json-file');
 
-const { addScript, removeScript } = require('../pkg.js')
+const { addScript, removeScript } = require('../pkg.js');
 const {
-  JSON_OPTIONS, PACKAGE_JSON, PACKAGE_JSON_DEVDEPS
-} = require('../values.js')
+  JSON_OPTIONS,
+  PACKAGE_JSON,
+  PACKAGE_JSON_DEVDEPS
+} = require('../values.js');
 
-const LABEL = 'fixpack installed and configured'
+const LABEL = 'fixpack installed and configured';
 
-function npmInstall (cwd) {
-  return execa('npm', [
-    'install', '--save-dev',
-    'fixpack'
-  ], { cwd })
+function npmInstall(cwd) {
+  return execa('npm', ['install', '--save-dev', 'fixpack'], { cwd });
 }
 
-function npmScript (cwd) {
-  return updateJsonFile(path.join(cwd, 'package.json'), (pkg) => {
-    pkg.scripts = pkg.scripts || {}
-    pkg.scripts.fixpack = 'fixpack'
+function npmScript(cwd) {
+  return updateJsonFile(
+    path.join(cwd, 'package.json'),
+    pkg => {
+      pkg.scripts = pkg.scripts || {};
+      pkg.scripts.fixpack = 'fixpack';
 
-    addScript(pkg, 'pretest', 'npm run fixpack')
-    removeScript(pkg, 'posttest', 'npm run fixpack')
+      addScript(pkg, 'pretest', 'npm run fixpack');
+      removeScript(pkg, 'posttest', 'npm run fixpack');
 
-    return pkg
-  }, JSON_OPTIONS)
+      return pkg;
+    },
+    JSON_OPTIONS
+  );
 }
 
 /* :: import type { TaskOptions } from '../types.js' */
 
-function fn ({ cwd } /* : TaskOptions */) {
-  return npmInstall(cwd)
-    .then(() => npmScript(cwd))
+function fn({ cwd } /* : TaskOptions */) {
+  return npmInstall(cwd).then(() => npmScript(cwd));
 }
 
 module.exports = {
   fn,
   id: path.basename(__filename),
   label: LABEL,
-  provides: [ PACKAGE_JSON_DEVDEPS ],
-  settles: [ PACKAGE_JSON ]
-}
+  provides: [PACKAGE_JSON_DEVDEPS],
+  settles: [PACKAGE_JSON]
+};

--- a/lib/tasks/flowtype-uninstall.js
+++ b/lib/tasks/flowtype-uninstall.js
@@ -1,61 +1,65 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const path = require('path')
+const path = require('path');
 
-const { hasAnnotatedFiles } = require('detect-flowtype')
-const execa = require('execa')
-const pify = require('pify')
-const rimraf = require('rimraf')
-const updateJsonFile = require('update-json-file')
+const { hasAnnotatedFiles } = require('detect-flowtype');
+const execa = require('execa');
+const pify = require('pify');
+const rimraf = require('rimraf');
+const updateJsonFile = require('update-json-file');
 
-const { removeScript } = require('../pkg.js')
+const { removeScript } = require('../pkg.js');
 const {
-  JSON_OPTIONS, PACKAGE_JSON, PACKAGE_JSON_DEVDEPS, PROJECT_CODE
-} = require('../values.js')
+  JSON_OPTIONS,
+  PACKAGE_JSON,
+  PACKAGE_JSON_DEVDEPS,
+  PROJECT_CODE
+} = require('../values.js');
 
-const LABEL = 'unused FlowType uninstalled and configured'
+const LABEL = 'unused FlowType uninstalled and configured';
 
-function npmUninstall (cwd /* : string */) {
-  return execa('npm', [
-    'uninstall', '--save-dev', 'flow-bin'
-  ], { cwd })
+function npmUninstall(cwd /* : string */) {
+  return execa('npm', ['uninstall', '--save-dev', 'flow-bin'], { cwd });
 }
 
-function npmScript (cwd /* : string */) {
-  return updateJsonFile(path.join(cwd, 'package.json'), (pkg) => {
-    pkg.scripts = pkg.scripts || {}
-    removeScript(pkg, 'test', 'npm run flow_check')
-    removeScript(pkg, 'posttest', 'npm run flow_check')
-    removeScript(pkg, 'pretest', 'npm run flow_check')
-    delete pkg.scripts.flow_check
-    return pkg
-  }, JSON_OPTIONS)
+function npmScript(cwd /* : string */) {
+  return updateJsonFile(
+    path.join(cwd, 'package.json'),
+    pkg => {
+      pkg.scripts = pkg.scripts || {};
+      removeScript(pkg, 'test', 'npm run flow_check');
+      removeScript(pkg, 'posttest', 'npm run flow_check');
+      removeScript(pkg, 'pretest', 'npm run flow_check');
+      delete pkg.scripts.flow_check;
+      return pkg;
+    },
+    JSON_OPTIONS
+  );
 }
 
 /* :: import type { TaskOptions } from '../types.js' */
 
-function deleteConfig (cwd /* : string */) {
-  const filePath = path.join(cwd, '.flowconfig')
-  return pify(rimraf)(filePath, { disableGlob: true })
+function deleteConfig(cwd /* : string */) {
+  const filePath = path.join(cwd, '.flowconfig');
+  return pify(rimraf)(filePath, { disableGlob: true });
 }
 
-function deleteFlowTyped (cwd /* : string */) {
-  const filePath = path.join(cwd, 'flow-typed')
-  return pify(rimraf)(filePath, { disableGlob: true })
+function deleteFlowTyped(cwd /* : string */) {
+  const filePath = path.join(cwd, 'flow-typed');
+  return pify(rimraf)(filePath, { disableGlob: true });
 }
 
-function fn ({ cwd } /* : TaskOptions */) {
+function fn({ cwd } /* : TaskOptions */) {
   return Promise.all([
     deleteConfig(cwd),
     deleteFlowTyped(cwd),
-    npmUninstall(cwd)
-      .then(() => npmScript(cwd))
-  ])
+    npmUninstall(cwd).then(() => npmScript(cwd))
+  ]);
 }
 
-function isNeeded ({ cwd } /* : TaskOptions */) {
-  return hasAnnotatedFiles({ dirPath: cwd }).then((result) => !result)
+function isNeeded({ cwd } /* : TaskOptions */) {
+  return hasAnnotatedFiles({ dirPath: cwd }).then(result => !result);
 }
 
 module.exports = {
@@ -63,6 +67,6 @@ module.exports = {
   id: path.basename(__filename),
   isNeeded,
   label: LABEL,
-  provides: [ PACKAGE_JSON_DEVDEPS ],
-  requires: [ PACKAGE_JSON, PROJECT_CODE ]
-}
+  provides: [PACKAGE_JSON_DEVDEPS],
+  requires: [PACKAGE_JSON, PROJECT_CODE]
+};

--- a/lib/tasks/flowtype.js
+++ b/lib/tasks/flowtype.js
@@ -1,62 +1,66 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const path = require('path')
+const path = require('path');
 
-const { hasAnnotatedFiles } = require('detect-flowtype')
-const execa = require('execa')
-const fetch = require('node-fetch')
-const updateJsonFile = require('update-json-file')
+const { hasAnnotatedFiles } = require('detect-flowtype');
+const execa = require('execa');
+const fetch = require('node-fetch');
+const updateJsonFile = require('update-json-file');
 
-const fs = require('../fs.js')
-const { getPkg } = require('../pkg.js')
+const fs = require('../fs.js');
+const { getPkg } = require('../pkg.js');
 const {
-  JSON_OPTIONS, PACKAGE_JSON, PACKAGE_JSON_DEVDEPS, PROJECT_CODE
-} = require('../values.js')
+  JSON_OPTIONS,
+  PACKAGE_JSON,
+  PACKAGE_JSON_DEVDEPS,
+  PROJECT_CODE
+} = require('../values.js');
 
-const LABEL = 'FlowType installed and configured'
+const LABEL = 'FlowType installed and configured';
 
-function npmInstall (cwd /* : string */) {
-  return getPkg(cwd)
-    .then(({ devDependencies }) => {
-      const devDeps = Object.keys(devDependencies || {})
-      if (!devDeps.includes('flow-bin')) {
-        return execa('npm', [
-          'install', '--save-dev', 'flow-bin'
-        ], { cwd })
-      }
-    })
+function npmInstall(cwd /* : string */) {
+  return getPkg(cwd).then(({ devDependencies }) => {
+    const devDeps = Object.keys(devDependencies || {});
+    if (!devDeps.includes('flow-bin')) {
+      return execa('npm', ['install', '--save-dev', 'flow-bin'], { cwd });
+    }
+  });
 }
 
-function npmScript (cwd /* : string */) {
-  return updateJsonFile(path.join(cwd, 'package.json'), (pkg) => {
-    pkg.scripts = pkg.scripts || {}
-    pkg.scripts.flow_check = 'flow check'
-    return pkg
-  }, JSON_OPTIONS)
+function npmScript(cwd /* : string */) {
+  return updateJsonFile(
+    path.join(cwd, 'package.json'),
+    pkg => {
+      pkg.scripts = pkg.scripts || {};
+      pkg.scripts.flow_check = 'flow check';
+      return pkg;
+    },
+    JSON_OPTIONS
+  );
 }
 
-const CONFIG_URL = 'https://raw.githubusercontent.com/jokeyrhyme/node-init.js/master/.flowconfig'
+const CONFIG_URL =
+  'https://raw.githubusercontent.com/jokeyrhyme/node-init.js/master/.flowconfig';
 
 /* :: import type { TaskOptions } from '../types.js' */
 
-function fetchConfig (cwd /* : string */) {
-  const filePath = path.join(cwd, '.flowconfig')
+function fetchConfig(cwd /* : string */) {
+  const filePath = path.join(cwd, '.flowconfig');
   return fetch(CONFIG_URL)
-    .then((res) => res.text())
-    .then((data) => fs.writeFile(filePath, data))
+    .then(res => res.text())
+    .then(data => fs.writeFile(filePath, data));
 }
 
-function fn ({ cwd } /* : TaskOptions */) {
+function fn({ cwd } /* : TaskOptions */) {
   return Promise.all([
     fetchConfig(cwd),
-    npmInstall(cwd)
-      .then(() => npmScript(cwd))
-  ])
+    npmInstall(cwd).then(() => npmScript(cwd))
+  ]);
 }
 
-function isNeeded ({ cwd } /* : TaskOptions */) {
-  return hasAnnotatedFiles({ dirPath: cwd })
+function isNeeded({ cwd } /* : TaskOptions */) {
+  return hasAnnotatedFiles({ dirPath: cwd });
 }
 
 module.exports = {
@@ -64,6 +68,6 @@ module.exports = {
   id: path.basename(__filename),
   isNeeded,
   label: LABEL,
-  provides: [ PACKAGE_JSON_DEVDEPS ],
-  requires: [ PACKAGE_JSON, PROJECT_CODE ]
-}
+  provides: [PACKAGE_JSON_DEVDEPS],
+  requires: [PACKAGE_JSON, PROJECT_CODE]
+};

--- a/lib/tasks/git-init.js
+++ b/lib/tasks/git-init.js
@@ -1,21 +1,21 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const path = require('path')
+const path = require('path');
 
-const { init, isGitProject } = require('../git.js')
-const { GIT_REPO } = require('../values.js')
+const { init, isGitProject } = require('../git.js');
+const { GIT_REPO } = require('../values.js');
 
-const LABEL = 'git project exists'
+const LABEL = 'git project exists';
 
 /* :: import type { TaskOptions } from '../types.js' */
 
-function fn ({ cwd } /* : TaskOptions */) {
-  return init(cwd)
+function fn({ cwd } /* : TaskOptions */) {
+  return init(cwd);
 }
 
-function isNeeded ({ cwd } /* : TaskOptions */) {
-  return isGitProject(cwd).then((result) => !result)
+function isNeeded({ cwd } /* : TaskOptions */) {
+  return isGitProject(cwd).then(result => !result);
 }
 
 module.exports = {
@@ -23,5 +23,5 @@ module.exports = {
   id: path.basename(__filename),
   isNeeded,
   label: LABEL,
-  provides: [ GIT_REPO ]
-}
+  provides: [GIT_REPO]
+};

--- a/lib/tasks/gitignore.js
+++ b/lib/tasks/gitignore.js
@@ -1,41 +1,46 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const os = require('os')
-const path = require('path')
+const os = require('os');
+const path = require('path');
 
-const through2 = require('through2')
-const vfs = require('vinyl-fs')
+const through2 = require('through2');
+const vfs = require('vinyl-fs');
 
-const fs = require('../fs.js')
+const fs = require('../fs.js');
 
-const LABEL = '.gitignore set for Node.js'
+const LABEL = '.gitignore set for Node.js';
 
 /* :: import type { TaskOptions } from '../types.js' */
 
-function fn ({ cwd } /* : TaskOptions */) {
-  return fs.touch(path.join(cwd, '.gitignore'))
-        .then(() => new Promise((resolve, reject) => {
-          vfs.src('.gitignore', { cwd })
-                .pipe(through2.obj((file, enc, cb) => {
-                  let contents = file.contents.toString(enc)
-                  if (!/\bnode_modules\b/.test(contents)) {
-                    contents += (`${os.EOL}node_modules${os.EOL}`)
-                  }
-                  if (!/\.eslintcache\b/.test(contents)) {
-                    contents += (`${os.EOL}.eslintcache${os.EOL}`)
-                  }
-                  file.contents = Buffer.from(contents, enc)
-                  cb(null, file)
-                }))
-                .pipe(vfs.dest(cwd))
-                .on('error', (err) => reject(err))
-                .on('end', () => resolve())
-        }))
+function fn({ cwd } /* : TaskOptions */) {
+  return fs.touch(path.join(cwd, '.gitignore')).then(
+    () =>
+      new Promise((resolve, reject) => {
+        vfs
+          .src('.gitignore', { cwd })
+          .pipe(
+            through2.obj((file, enc, cb) => {
+              let contents = file.contents.toString(enc);
+              if (!/\bnode_modules\b/.test(contents)) {
+                contents += `${os.EOL}node_modules${os.EOL}`;
+              }
+              if (!/\.eslintcache\b/.test(contents)) {
+                contents += `${os.EOL}.eslintcache${os.EOL}`;
+              }
+              file.contents = Buffer.from(contents, enc);
+              cb(null, file);
+            })
+          )
+          .pipe(vfs.dest(cwd))
+          .on('error', err => reject(err))
+          .on('end', () => resolve());
+      })
+  );
 }
 
 module.exports = {
   fn,
   id: path.basename(__filename),
   label: LABEL
-}
+};

--- a/lib/tasks/gitlab-ci.yml.js
+++ b/lib/tasks/gitlab-ci.yml.js
@@ -1,61 +1,62 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const path = require('path')
+const path = require('path');
 
-const { safeDump, safeLoad } = require('js-yaml')
-const readPkgUp = require('read-pkg-up')
-const union = require('lodash.union')
+const { safeDump, safeLoad } = require('js-yaml');
+const readPkgUp = require('read-pkg-up');
+const union = require('lodash.union');
 
-const { ensureArrayTail } = require('../data.js')
-const fs = require('../fs.js')
-const { isPublicGitHubOrBitbucket } = require('../git.js')
-const { fetchSupportedMajors } = require('../nodejs-versions.js')
-const { GIT_REPO, PACKAGE_JSON } = require('../values.js')
+const { ensureArrayTail } = require('../data.js');
+const fs = require('../fs.js');
+const { isPublicGitHubOrBitbucket } = require('../git.js');
+const { fetchSupportedMajors } = require('../nodejs-versions.js');
+const { GIT_REPO, PACKAGE_JSON } = require('../values.js');
 
-const LABEL = '.gitlab-ci.yml initialised'
+const LABEL = '.gitlab-ci.yml initialised';
 
 /* :: import type { TaskOptions } from '../types.js' */
 
-function fn ({ cwd } /* : TaskOptions */) {
-  const filePath = path.join(cwd, '.gitlab-ci.yml')
+function fn({ cwd } /* : TaskOptions */) {
+  const filePath = path.join(cwd, '.gitlab-ci.yml');
   return readPkgUp({ cwd })
     .then(({ pkg }) => fetchSupportedMajors((pkg.engines || {}).node))
-    .then((majors) => {
-      return fs.touch(filePath)
+    .then(majors => {
+      return fs
+        .touch(filePath)
         .then(() => fs.readFile(filePath, 'utf8'))
         .then(safeLoad)
-        .then((cfg) => {
-          cfg = cfg || {}
+        .then(cfg => {
+          cfg = cfg || {};
 
           cfg.before_script = union(cfg.before_script || [], [
             'apt-get update -qq',
             'apt-get install -qy libelf1',
             'npm install --global npm',
             'npm install --global yarn'
-          ])
+          ]);
 
-          cfg.before_script = ensureArrayTail(cfg.before_script || [], 'npm install')
+          cfg.before_script = ensureArrayTail(
+            cfg.before_script || [],
+            'npm install'
+          );
 
-          cfg.test = cfg.test || {}
+          cfg.test = cfg.test || {};
 
           // test against the oldest supported major version of Node.js
-          cfg.test.image = cfg.test.image || 'node:' + majors[0]
+          cfg.test.image = cfg.test.image || 'node:' + majors[0];
 
-          cfg.test.script = union(cfg.test.script || [], [
-            'npm test'
-          ])
+          cfg.test.script = union(cfg.test.script || [], ['npm test']);
 
-          return safeDump(cfg)
+          return safeDump(cfg);
         })
-        .then((data) => fs.writeFile(filePath, data))
-    })
+        .then(data => fs.writeFile(filePath, data));
+    });
 }
 
-function isNeeded ({ cwd } /* : TaskOptions */) {
+function isNeeded({ cwd } /* : TaskOptions */) {
   // if not GitHub or Bitbucket, then assume GitLab
-  return isPublicGitHubOrBitbucket(cwd)
-    .then((result) => !result)
+  return isPublicGitHubOrBitbucket(cwd).then(result => !result);
 }
 
 module.exports = {
@@ -63,5 +64,5 @@ module.exports = {
   id: path.basename(__filename),
   isNeeded,
   label: LABEL,
-  requires: [ GIT_REPO, PACKAGE_JSON ]
-}
+  requires: [GIT_REPO, PACKAGE_JSON]
+};

--- a/lib/tasks/gitlab-ci.yml.js
+++ b/lib/tasks/gitlab-ci.yml.js
@@ -9,7 +9,7 @@ const union = require('lodash.union')
 
 const { ensureArrayTail } = require('../data.js')
 const fs = require('../fs.js')
-const { getOriginUrl, isPublicGitHubOrBitbucket } = require('../git.js')
+const { isPublicGitHubOrBitbucket } = require('../git.js')
 const { fetchSupportedMajors } = require('../nodejs-versions.js')
 const { GIT_REPO, PACKAGE_JSON } = require('../values.js')
 
@@ -19,12 +19,9 @@ const LABEL = '.gitlab-ci.yml initialised'
 
 function fn ({ cwd } /* : TaskOptions */) {
   const filePath = path.join(cwd, '.gitlab-ci.yml')
-  return Promise.all([
-    getOriginUrl(cwd),
-    readPkgUp({ cwd })
-      .then(({ pkg }) => fetchSupportedMajors((pkg.engines || {}).node))
-  ])
-    .then(([ originUrl, majors ]) => {
+  return readPkgUp({ cwd })
+    .then(({ pkg }) => fetchSupportedMajors((pkg.engines || {}).node))
+    .then((majors) => {
       return fs.touch(filePath)
         .then(() => fs.readFile(filePath, 'utf8'))
         .then(safeLoad)

--- a/lib/tasks/greenkeeper.js
+++ b/lib/tasks/greenkeeper.js
@@ -30,7 +30,7 @@ function pkgUpdater (pkg /* : PackageJSON */) {
   return pkg
 }
 
-function fn ({ cwd, scope } /* : TaskOptions */) {
+function fn ({ cwd } /* : TaskOptions */) {
   return updateJsonFile(
     path.join(cwd, 'package.json'),
     pkgUpdater,

--- a/lib/tasks/greenkeeper.js
+++ b/lib/tasks/greenkeeper.js
@@ -1,41 +1,41 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const path = require('path')
+const path = require('path');
 
-const updateJsonFile = require('update-json-file')
+const updateJsonFile = require('update-json-file');
 
-const { JSON_OPTIONS, PACKAGE_JSON } = require('../values.js')
+const { JSON_OPTIONS, PACKAGE_JSON } = require('../values.js');
 
-const LABEL = 'greenkeeper.io integration'
+const LABEL = 'greenkeeper.io integration';
 
 /* :: import type { PackageJSON, TaskOptions } from '../types.js' */
 
-function pkgUpdater (pkg /* : PackageJSON */) {
+function pkgUpdater(pkg /* : PackageJSON */) {
   // greenkeeper no longer requires publish-hook integration
-  const { devDependencies = {}, scripts = {} } = pkg
+  const { devDependencies = {}, scripts = {} } = pkg;
 
-  delete (devDependencies || {})['greenkeeper-postpublish']
+  delete (devDependencies || {})['greenkeeper-postpublish'];
   if (!Object.keys(devDependencies).length) {
-    delete pkg.devDependencies
+    delete pkg.devDependencies;
   }
 
   if (scripts.postpublish === 'greenkeeper-postpublish') {
-    delete scripts.postpublish
+    delete scripts.postpublish;
   }
   if (!Object.keys(scripts).length) {
-    delete pkg.scripts
+    delete pkg.scripts;
   }
 
-  return pkg
+  return pkg;
 }
 
-function fn ({ cwd } /* : TaskOptions */) {
+function fn({ cwd } /* : TaskOptions */) {
   return updateJsonFile(
     path.join(cwd, 'package.json'),
     pkgUpdater,
     JSON_OPTIONS
-  )
+  );
 }
 
 module.exports = {
@@ -43,5 +43,5 @@ module.exports = {
   id: path.basename(__filename),
   label: LABEL,
   pkgUpdater,
-  requires: [ PACKAGE_JSON ]
-}
+  requires: [PACKAGE_JSON]
+};

--- a/lib/tasks/jsconfig.json.js
+++ b/lib/tasks/jsconfig.json.js
@@ -1,36 +1,41 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const path = require('path')
+const path = require('path');
 
-const union = require('lodash.union')
-const updateJsonFile = require('update-json-file')
+const union = require('lodash.union');
+const updateJsonFile = require('update-json-file');
 
-const { JSON_OPTIONS } = require('../values.js')
+const { JSON_OPTIONS } = require('../values.js');
 
-const LABEL = 'jsconfig.json configured'
+const LABEL = 'jsconfig.json configured';
 
-function jsconfig (cwd) {
-  return updateJsonFile(path.join(cwd, 'jsconfig.json'), (rc) => {
-    rc.compilerOptions = rc.compilerOptions || {}
-    rc.compilerOptions.target = rc.compilerOptions.target || 'ES6'
-    rc.compilerOptions.allowSyntheticDefaultImports = rc.compilerOptions.allowSyntheticDefaultImports || true
+function jsconfig(cwd) {
+  return updateJsonFile(
+    path.join(cwd, 'jsconfig.json'),
+    rc => {
+      rc.compilerOptions = rc.compilerOptions || {};
+      rc.compilerOptions.target = rc.compilerOptions.target || 'ES6';
+      rc.compilerOptions.allowSyntheticDefaultImports =
+        rc.compilerOptions.allowSyntheticDefaultImports || true;
 
-    rc.exclude = rc.exclude || []
-    rc.exclude = union(rc.exclude, [ 'node_modules' ])
+      rc.exclude = rc.exclude || [];
+      rc.exclude = union(rc.exclude, ['node_modules']);
 
-    return rc
-  }, JSON_OPTIONS)
+      return rc;
+    },
+    JSON_OPTIONS
+  );
 }
 
 /* :: import type { TaskOptions } from '../types.js' */
 
-function fn ({ cwd } /* : TaskOptions */) {
-  return jsconfig(cwd)
+function fn({ cwd } /* : TaskOptions */) {
+  return jsconfig(cwd);
 }
 
 module.exports = {
   fn,
   id: path.basename(__filename),
   label: LABEL
-}
+};

--- a/lib/tasks/npm-dev-deps.js
+++ b/lib/tasks/npm-dev-deps.js
@@ -1,35 +1,41 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const path = require('path')
+const path = require('path');
 
-const semver = require('semver')
-const updateJsonFile = require('update-json-file')
+const semver = require('semver');
+const updateJsonFile = require('update-json-file');
 
 const {
-  JSON_OPTIONS, PACKAGE_JSON, PACKAGE_JSON_DEVDEPS
-} = require('../values.js')
+  JSON_OPTIONS,
+  PACKAGE_JSON,
+  PACKAGE_JSON_DEVDEPS
+} = require('../values.js');
 
-const LABEL = 'devDeps in package.json permit MINOR and PATCH updates'
+const LABEL = 'devDeps in package.json permit MINOR and PATCH updates';
 
 /* :: import type { TaskOptions } from '../types.js' */
 
-function fn ({ cwd } /* : TaskOptions */) {
-  return updateJsonFile(path.join(cwd, 'package.json'), (pkg) => {
-    pkg.devDependencies = pkg.devDependencies || {}
-    Object.keys(pkg.devDependencies).forEach((dep) => {
-      const version = pkg.devDependencies[dep]
-      if (semver.valid(version)) {
-        pkg.devDependencies[dep] = version.replace(/^\D*(\d)/, '^$1')
-      }
-    })
-    return pkg
-  }, JSON_OPTIONS)
+function fn({ cwd } /* : TaskOptions */) {
+  return updateJsonFile(
+    path.join(cwd, 'package.json'),
+    pkg => {
+      pkg.devDependencies = pkg.devDependencies || {};
+      Object.keys(pkg.devDependencies).forEach(dep => {
+        const version = pkg.devDependencies[dep];
+        if (semver.valid(version)) {
+          pkg.devDependencies[dep] = version.replace(/^\D*(\d)/, '^$1');
+        }
+      });
+      return pkg;
+    },
+    JSON_OPTIONS
+  );
 }
 
 module.exports = {
   fn,
   id: path.basename(__filename),
   label: LABEL,
-  settles: [ PACKAGE_JSON, PACKAGE_JSON_DEVDEPS ]
-}
+  settles: [PACKAGE_JSON, PACKAGE_JSON_DEVDEPS]
+};

--- a/lib/tasks/npm-engines.js
+++ b/lib/tasks/npm-engines.js
@@ -1,33 +1,39 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const path = require('path')
+const path = require('path');
 
-const execa = require('execa')
-const semver = require('semver')
-const updateJsonFile = require('update-json-file')
+const execa = require('execa');
+const semver = require('semver');
+const updateJsonFile = require('update-json-file');
 
-const { JSON_OPTIONS, PACKAGE_JSON } = require('../values.js')
+const { JSON_OPTIONS, PACKAGE_JSON } = require('../values.js');
 
-const LABEL = '"engines" set in package.json'
+const LABEL = '"engines" set in package.json';
 
 /* :: import type { TaskOptions } from '../types.js' */
 
-function fn ({ cwd } /* : TaskOptions */) {
-  const node = semver.major(process.version)
-  return execa('npm', [ '--version' ])
-    .then((result) => semver.major(result.stdout))
-    .then((npm) => updateJsonFile(path.join(cwd, 'package.json'), (pkg) => {
-      pkg.engines = pkg.engines || {}
-      pkg.engines.node = pkg.engines.node || `>=${node}`
-      pkg.engines.npm = pkg.engines.npm || `>=${npm}`
-      return pkg
-    }, JSON_OPTIONS))
+function fn({ cwd } /* : TaskOptions */) {
+  const node = semver.major(process.version);
+  return execa('npm', ['--version'])
+    .then(result => semver.major(result.stdout))
+    .then(npm =>
+      updateJsonFile(
+        path.join(cwd, 'package.json'),
+        pkg => {
+          pkg.engines = pkg.engines || {};
+          pkg.engines.node = pkg.engines.node || `>=${node}`;
+          pkg.engines.npm = pkg.engines.npm || `>=${npm}`;
+          return pkg;
+        },
+        JSON_OPTIONS
+      )
+    );
 }
 
 module.exports = {
   fn,
   id: path.basename(__filename),
   label: LABEL,
-  requires: [ PACKAGE_JSON ]
-}
+  requires: [PACKAGE_JSON]
+};

--- a/lib/tasks/npm-init.js
+++ b/lib/tasks/npm-init.js
@@ -1,30 +1,35 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const path = require('path')
+const path = require('path');
 
-const execa = require('execa')
-const updateJsonFile = require('update-json-file')
+const execa = require('execa');
+const updateJsonFile = require('update-json-file');
 
-const { GIT_REPO, JSON_OPTIONS, PACKAGE_JSON } = require('../values.js')
+const { GIT_REPO, JSON_OPTIONS, PACKAGE_JSON } = require('../values.js');
 
-const LABEL = 'npm package.json initialised'
+const LABEL = 'npm package.json initialised';
 
 /* :: import type { TaskOptions } from '../types.js' */
 
-function fn ({ cwd } /* : TaskOptions */) {
-  return execa('npm', ['init', '-y'], { cwd })
-    .then(() => updateJsonFile(path.join(cwd, 'package.json'), (pkg) => {
-      // https://github.com/jokeyrhyme/node-init.js/issues/96
-      pkg.dependencies = pkg.dependencies || {}
-      return pkg
-    }, JSON_OPTIONS))
+function fn({ cwd } /* : TaskOptions */) {
+  return execa('npm', ['init', '-y'], { cwd }).then(() =>
+    updateJsonFile(
+      path.join(cwd, 'package.json'),
+      pkg => {
+        // https://github.com/jokeyrhyme/node-init.js/issues/96
+        pkg.dependencies = pkg.dependencies || {};
+        return pkg;
+      },
+      JSON_OPTIONS
+    )
+  );
 }
 
 module.exports = {
   fn,
   id: path.basename(__filename),
   label: LABEL,
-  provides: [ PACKAGE_JSON ],
-  requires: [ GIT_REPO ]
-}
+  provides: [PACKAGE_JSON],
+  requires: [GIT_REPO]
+};

--- a/lib/tasks/npm-name.js
+++ b/lib/tasks/npm-name.js
@@ -1,30 +1,36 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const path = require('path')
+const path = require('path');
 
-const updateJsonFile = require('update-json-file')
+const updateJsonFile = require('update-json-file');
 
-const { injectScope } = require('../pkg.js')
+const { injectScope } = require('../pkg.js');
 const {
-  JSON_OPTIONS, PACKAGE_JSON, PACKAGE_JSON_NAME
-} = require('../values.js')
+  JSON_OPTIONS,
+  PACKAGE_JSON,
+  PACKAGE_JSON_NAME
+} = require('../values.js');
 
-const LABEL = '"name" with optional @scope set in package.json'
+const LABEL = '"name" with optional @scope set in package.json';
 
 /* :: import type { TaskOptions } from '../types.js' */
 
-function fn ({ cwd, scope } /* : TaskOptions */) {
-  return updateJsonFile(path.join(cwd, 'package.json'), (pkg) => {
-    pkg.name = injectScope(scope, pkg.name)
-    return pkg
-  }, JSON_OPTIONS)
+function fn({ cwd, scope } /* : TaskOptions */) {
+  return updateJsonFile(
+    path.join(cwd, 'package.json'),
+    pkg => {
+      pkg.name = injectScope(scope, pkg.name);
+      return pkg;
+    },
+    JSON_OPTIONS
+  );
 }
 
 module.exports = {
   fn,
   id: path.basename(__filename),
   label: LABEL,
-  provides: [ PACKAGE_JSON_NAME ],
-  requires: [ PACKAGE_JSON ]
-}
+  provides: [PACKAGE_JSON_NAME],
+  requires: [PACKAGE_JSON]
+};

--- a/lib/tasks/npm-publish-config.js
+++ b/lib/tasks/npm-publish-config.js
@@ -1,29 +1,33 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const path = require('path')
-const updateJsonFile = require('update-json-file')
+const path = require('path');
+const updateJsonFile = require('update-json-file');
 
-const { JSON_OPTIONS, PACKAGE_JSON } = require('../values.js')
+const { JSON_OPTIONS, PACKAGE_JSON } = require('../values.js');
 
-const LABEL = '"publishConfig" for @scope (if any) set in package.json'
+const LABEL = '"publishConfig" for @scope (if any) set in package.json';
 
 /* :: import type { TaskOptions } from '../types.js' */
 
-function fn ({ cwd, scope } /* : TaskOptions */) {
+function fn({ cwd, scope } /* : TaskOptions */) {
   if (!scope) {
-    return Promise.resolve()
+    return Promise.resolve();
   }
-  return updateJsonFile(path.join(cwd, 'package.json'), (pkg) => {
-    pkg.publishConfig = pkg.publishConfig || {}
-    pkg.publishConfig.access = pkg.publishConfig.access || 'public'
-    return pkg
-  }, JSON_OPTIONS)
+  return updateJsonFile(
+    path.join(cwd, 'package.json'),
+    pkg => {
+      pkg.publishConfig = pkg.publishConfig || {};
+      pkg.publishConfig.access = pkg.publishConfig.access || 'public';
+      return pkg;
+    },
+    JSON_OPTIONS
+  );
 }
 
 module.exports = {
   fn,
   id: path.basename(__filename),
   label: LABEL,
-  requires: [ PACKAGE_JSON ]
-}
+  requires: [PACKAGE_JSON]
+};

--- a/lib/tasks/npm-test.js
+++ b/lib/tasks/npm-test.js
@@ -1,58 +1,62 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const path = require('path')
-const updateJsonFile = require('update-json-file')
+const path = require('path');
+const updateJsonFile = require('update-json-file');
 
-const { JSON_OPTIONS, PACKAGE_JSON } = require('../values.js')
+const { JSON_OPTIONS, PACKAGE_JSON } = require('../values.js');
 
-const LABEL = '`npm test` executes installed test runners'
+const LABEL = '`npm test` executes installed test runners';
 
 /* :: import type { TaskOptions } from '../types.js' */
 
-function fn ({ cwd } /* : TaskOptions */) {
-  return updateJsonFile(path.join(cwd, 'package.json'), (pkg) => {
-    const devDeps = pkg.devDependencies || {}
-    if (devDeps.ava) {
-      pkg.scripts = Object.assign({}, pkg.scripts, {
-        ava: 'ava'
-      })
-      if (devDeps.nyc) {
+function fn({ cwd } /* : TaskOptions */) {
+  return updateJsonFile(
+    path.join(cwd, 'package.json'),
+    pkg => {
+      const devDeps = pkg.devDependencies || {};
+      if (devDeps.ava) {
         pkg.scripts = Object.assign({}, pkg.scripts, {
-          ava: 'nyc ava',
-          nyc: 'nyc check-coverage'
-        })
+          ava: 'ava'
+        });
+        if (devDeps.nyc) {
+          pkg.scripts = Object.assign({}, pkg.scripts, {
+            ava: 'nyc ava',
+            nyc: 'nyc check-coverage'
+          });
+        }
       }
-    }
 
-    if (devDeps.jest) {
-      pkg.scripts = Object.assign({}, pkg.scripts, {
-        jest: 'jest'
-      })
-      pkg.jest = Object.assign({}, pkg.jest, {
-        collectCoverage: true,
-        coverageThreshold: {
-          global: {
-            lines: 90
-          }
-        },
-        testRegex: '/__tests__/[^\\/]*\\.js$'
-      })
-    }
+      if (devDeps.jest) {
+        pkg.scripts = Object.assign({}, pkg.scripts, {
+          jest: 'jest'
+        });
+        pkg.jest = Object.assign({}, pkg.jest, {
+          collectCoverage: true,
+          coverageThreshold: {
+            global: {
+              lines: 90
+            }
+          },
+          testRegex: '/__tests__/[^\\/]*\\.js$'
+        });
+      }
 
-    if (devDeps.mocha) {
-      pkg.scripts = Object.assign({}, pkg.scripts, {
-        mocha: 'mocha'
-      })
-    }
+      if (devDeps.mocha) {
+        pkg.scripts = Object.assign({}, pkg.scripts, {
+          mocha: 'mocha'
+        });
+      }
 
-    return pkg
-  }, JSON_OPTIONS)
+      return pkg;
+    },
+    JSON_OPTIONS
+  );
 }
 
 module.exports = {
   fn,
   id: path.basename(__filename),
   label: LABEL,
-  requires: [ PACKAGE_JSON ]
-}
+  requires: [PACKAGE_JSON]
+};

--- a/lib/tasks/npm-test.js
+++ b/lib/tasks/npm-test.js
@@ -10,7 +10,7 @@ const LABEL = '`npm test` executes installed test runners'
 
 /* :: import type { TaskOptions } from '../types.js' */
 
-function fn ({ cwd, scope } /* : TaskOptions */) {
+function fn ({ cwd } /* : TaskOptions */) {
   return updateJsonFile(path.join(cwd, 'package.json'), (pkg) => {
     const devDeps = pkg.devDependencies || {}
     if (devDeps.ava) {

--- a/lib/tasks/pkg-main.js
+++ b/lib/tasks/pkg-main.js
@@ -1,36 +1,36 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const path = require('path')
+const path = require('path');
 
-const readPkgUp = require('read-pkg-up')
+const readPkgUp = require('read-pkg-up');
 
-const fs = require('../fs.js')
-const { PACKAGE_JSON, PROJECT_CODE } = require('../values.js')
+const fs = require('../fs.js');
+const { PACKAGE_JSON, PROJECT_CODE } = require('../values.js');
 
-const LABEL = 'package "main" points to a file that exists'
+const LABEL = 'package "main" points to a file that exists';
 
-const SKELETON_INDEX_PATH = path.join(__dirname, '..', 'skeleton', 'index.js')
+const SKELETON_INDEX_PATH = path.join(__dirname, '..', 'skeleton', 'index.js');
 
 /* :: import type { TaskOptions } from '../types.js' */
 
-function fn ({ cwd } /* : TaskOptions */) {
-  return readPkgUp({ cwd })
-    .then(({ pkg, path: pkgPath }) => {
-      if (!pkg.main || typeof pkg.main !== 'string') {
-        return
-      }
+function fn({ cwd } /* : TaskOptions */) {
+  return readPkgUp({ cwd }).then(({ pkg, path: pkgPath }) => {
+    if (!pkg.main || typeof pkg.main !== 'string') {
+      return;
+    }
 
-      const mainPath = path.join(path.dirname(pkgPath), pkg.main)
-      return fs.access(mainPath)
-        .catch(() => fs.copyFile(SKELETON_INDEX_PATH, mainPath))
-    })
+    const mainPath = path.join(path.dirname(pkgPath), pkg.main);
+    return fs
+      .access(mainPath)
+      .catch(() => fs.copyFile(SKELETON_INDEX_PATH, mainPath));
+  });
 }
 
 module.exports = {
   fn,
   id: path.basename(__filename),
   label: LABEL,
-  provides: [ PROJECT_CODE ],
-  requires: [ PACKAGE_JSON ]
-}
+  provides: [PROJECT_CODE],
+  requires: [PACKAGE_JSON]
+};

--- a/lib/tasks/prettier.js
+++ b/lib/tasks/prettier.js
@@ -1,0 +1,47 @@
+/* @flow */
+'use strict'
+
+const path = require('path')
+
+const execa = require('execa')
+const updateJsonFile = require('update-json-file')
+
+const { addScript } = require('../pkg.js')
+const {
+  JSON_OPTIONS, PACKAGE_JSON, PACKAGE_JSON_DEVDEPS
+} = require('../values.js')
+
+const LABEL = 'prettier installed and configured'
+
+function npmInstall(cwd) {
+  return execa('npm', [
+    'install', '--save-dev',
+    'prettier'
+  ], { cwd })
+}
+
+function npmScript(cwd) {
+  return updateJsonFile(path.join(cwd, 'package.json'), (pkg) => {
+    pkg.scripts = pkg.scripts || {}
+    pkg.scripts.prettier = 'prettier --single-quote --write "{,!(build|coverage|dist|node_modules)/**/}*.js"'
+
+    addScript(pkg, 'pretest', 'npm run prettier')
+
+    return pkg
+  }, JSON_OPTIONS)
+}
+
+/* :: import type { TaskOptions } from '../types.js' */
+
+function fn({ cwd } /* : TaskOptions */) {
+  return npmInstall(cwd)
+    .then(() => npmScript(cwd))
+}
+
+module.exports = {
+  fn,
+  id: path.basename(__filename),
+  label: LABEL,
+  provides: [PACKAGE_JSON_DEVDEPS],
+  requires: [PACKAGE_JSON]
+}

--- a/lib/tasks/prettier.js
+++ b/lib/tasks/prettier.js
@@ -1,41 +1,44 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const path = require('path')
+const path = require('path');
 
-const execa = require('execa')
-const updateJsonFile = require('update-json-file')
+const execa = require('execa');
+const updateJsonFile = require('update-json-file');
 
-const { addScript } = require('../pkg.js')
+const { addScript } = require('../pkg.js');
 const {
-  JSON_OPTIONS, PACKAGE_JSON, PACKAGE_JSON_DEVDEPS
-} = require('../values.js')
+  JSON_OPTIONS,
+  PACKAGE_JSON,
+  PACKAGE_JSON_DEVDEPS
+} = require('../values.js');
 
-const LABEL = 'prettier installed and configured'
+const LABEL = 'prettier installed and configured';
 
 function npmInstall(cwd) {
-  return execa('npm', [
-    'install', '--save-dev',
-    'prettier'
-  ], { cwd })
+  return execa('npm', ['install', '--save-dev', 'prettier'], { cwd });
 }
 
 function npmScript(cwd) {
-  return updateJsonFile(path.join(cwd, 'package.json'), (pkg) => {
-    pkg.scripts = pkg.scripts || {}
-    pkg.scripts.prettier = 'prettier --single-quote --write "{,!(build|coverage|dist|node_modules)/**/}*.js"'
+  return updateJsonFile(
+    path.join(cwd, 'package.json'),
+    pkg => {
+      pkg.scripts = pkg.scripts || {};
+      pkg.scripts.prettier =
+        'prettier --single-quote --write "{,!(build|coverage|dist|node_modules)/**/}*.js"';
 
-    addScript(pkg, 'pretest', 'npm run prettier')
+      addScript(pkg, 'pretest', 'npm run prettier');
 
-    return pkg
-  }, JSON_OPTIONS)
+      return pkg;
+    },
+    JSON_OPTIONS
+  );
 }
 
 /* :: import type { TaskOptions } from '../types.js' */
 
 function fn({ cwd } /* : TaskOptions */) {
-  return npmInstall(cwd)
-    .then(() => npmScript(cwd))
+  return npmInstall(cwd).then(() => npmScript(cwd));
 }
 
 module.exports = {
@@ -44,4 +47,4 @@ module.exports = {
   label: LABEL,
   provides: [PACKAGE_JSON_DEVDEPS],
   requires: [PACKAGE_JSON]
-}
+};

--- a/lib/tasks/travis.yml.js
+++ b/lib/tasks/travis.yml.js
@@ -10,7 +10,7 @@ const without = require('lodash.without')
 
 const { ensureArrayTail } = require('../data.js')
 const fs = require('../fs.js')
-const { getOriginUrl, isPublicGitHub } = require('../git.js')
+const { isPublicGitHub } = require('../git.js')
 const { fetchSupportedMajors } = require('../nodejs-versions.js')
 const { GIT_REPO, PACKAGE_JSON } = require('../values.js')
 
@@ -72,12 +72,9 @@ function updateNpm (cfg /* : Object */) /* : Object */ {
 
 function fn ({ cwd } /* : TaskOptions */) {
   const filePath = path.join(cwd, '.travis.yml')
-  return Promise.all([
-    getOriginUrl(cwd),
-    readPkgUp({ cwd })
-      .then(({ pkg }) => fetchSupportedMajors((pkg.engines || {}).node))
-  ])
-    .then(([ originUrl, majors ]) => {
+  return readPkgUp({ cwd })
+    .then(({ pkg }) => fetchSupportedMajors((pkg.engines || {}).node))
+    .then((majors) => {
       return fs.touch(filePath)
         .then(() => fs.readFile(filePath, 'utf8'))
         .then(safeLoad)

--- a/lib/tasks/travis.yml.js
+++ b/lib/tasks/travis.yml.js
@@ -1,118 +1,115 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const path = require('path')
+const path = require('path');
 
-const { safeDump, safeLoad } = require('js-yaml')
-const readPkgUp = require('read-pkg-up')
-const union = require('lodash.union')
-const without = require('lodash.without')
+const { safeDump, safeLoad } = require('js-yaml');
+const readPkgUp = require('read-pkg-up');
+const union = require('lodash.union');
+const without = require('lodash.without');
 
-const { ensureArrayTail } = require('../data.js')
-const fs = require('../fs.js')
-const { isPublicGitHub } = require('../git.js')
-const { fetchSupportedMajors } = require('../nodejs-versions.js')
-const { GIT_REPO, PACKAGE_JSON } = require('../values.js')
+const { ensureArrayTail } = require('../data.js');
+const fs = require('../fs.js');
+const { isPublicGitHub } = require('../git.js');
+const { fetchSupportedMajors } = require('../nodejs-versions.js');
+const { GIT_REPO, PACKAGE_JSON } = require('../values.js');
 
-const LABEL = '.travis.yml initialised'
+const LABEL = '.travis.yml initialised';
 
 /* :: import type { TaskOptions } from '../types.js' */
 
-function pruneCache (cfg /* : Object */) /* : Object */ {
+function pruneCache(cfg /* : Object */) /* : Object */ {
   // anything to do with npm's cache is likely to cause EPERMs
-  cfg.cache = without(cfg.cache || [], 'node_modules')
+  cfg.cache = without(cfg.cache || [], 'node_modules');
 
-  cfg.cache = cfg.cache || {}
-  cfg.cache.directories = without(
-    cfg.cache.directories || [],
-    'node_modules'
-  )
+  cfg.cache = cfg.cache || {};
+  cfg.cache.directories = without(cfg.cache.directories || [], 'node_modules');
 
   // remove completely if empty
   if (!cfg.cache.directories.length) {
-    delete cfg.cache.directories
+    delete cfg.cache.directories;
   }
   if (!Object.keys(cfg.cache).length) {
-    delete cfg.cache
+    delete cfg.cache;
   }
 
-  return cfg
+  return cfg;
 }
 
-function pruneInstall (cfg /* : Object */) /* : Object */ {
+function pruneInstall(cfg /* : Object */) /* : Object */ {
   // was never a good idea to install types definitions on-the-fly
   cfg.install = without(
     cfg.install || [],
     'npm install --global flow-typed',
     'npm install --global typings'
-  )
+  );
 
   // anything to do with npm's cache is likely to cause EPERMs
-  cfg.install = without(
-    cfg.install || [],
-    'npm cache clean'
-  )
+  cfg.install = without(cfg.install || [], 'npm cache clean');
 
   // remove completely if empty
   if (!cfg.install.length) {
-    delete cfg.install
+    delete cfg.install;
   }
 
-  return cfg
+  return cfg;
 }
 
-function updateNpm (cfg /* : Object */) /* : Object */ {
+function updateNpm(cfg /* : Object */) /* : Object */ {
   cfg.install = union(cfg.install || [], [
     'npm install --global npm',
     'npm install --global yarn'
-  ])
+  ]);
 
-  return cfg
+  return cfg;
 }
 
-function fn ({ cwd } /* : TaskOptions */) {
-  const filePath = path.join(cwd, '.travis.yml')
+function fn({ cwd } /* : TaskOptions */) {
+  const filePath = path.join(cwd, '.travis.yml');
   return readPkgUp({ cwd })
     .then(({ pkg }) => fetchSupportedMajors((pkg.engines || {}).node))
-    .then((majors) => {
-      return fs.touch(filePath)
+    .then(majors => {
+      return fs
+        .touch(filePath)
         .then(() => fs.readFile(filePath, 'utf8'))
         .then(safeLoad)
-        .then((cfg) => {
-          cfg = cfg || {}
-          cfg.language = cfg.language || 'node_js'
-          cfg.sudo = cfg.sudo || false
+        .then(cfg => {
+          cfg = cfg || {};
+          cfg.language = cfg.language || 'node_js';
+          cfg.sudo = cfg.sudo || false;
 
-          cfg.node_js = cfg.node_js || []
-          cfg.node_js = union(cfg.node_js, majors.map((major) => '' + major))
+          cfg.node_js = cfg.node_js || [];
+          cfg.node_js = union(cfg.node_js, majors.map(major => '' + major));
 
-          cfg.env = cfg.env || {}
-          cfg.env.global = cfg.env.global || []
-          cfg.env.global = union(cfg.env.global, [ 'CXX=g++-4.8' ])
+          cfg.env = cfg.env || {};
+          cfg.env.global = cfg.env.global || [];
+          cfg.env.global = union(cfg.env.global, ['CXX=g++-4.8']);
 
-          cfg.addons = cfg.addons || {}
-          cfg.addons.apt = cfg.addons.apt || {}
-          cfg.addons.apt.sources = cfg.addons.apt.sources || []
-          cfg.addons.apt.sources = union(cfg.addons.apt.sources, [ 'ubuntu-toolchain-r-test' ])
-          cfg.addons.apt.packages = cfg.addons.apt.packages || []
-          cfg.addons.apt.packages = union(cfg.addons.apt.packages, [ 'g++-4.8' ])
+          cfg.addons = cfg.addons || {};
+          cfg.addons.apt = cfg.addons.apt || {};
+          cfg.addons.apt.sources = cfg.addons.apt.sources || [];
+          cfg.addons.apt.sources = union(cfg.addons.apt.sources, [
+            'ubuntu-toolchain-r-test'
+          ]);
+          cfg.addons.apt.packages = cfg.addons.apt.packages || [];
+          cfg.addons.apt.packages = union(cfg.addons.apt.packages, ['g++-4.8']);
 
-          cfg = updateNpm(cfg)
+          cfg = updateNpm(cfg);
 
-          cfg.install = ensureArrayTail(cfg.install || [], 'npm install')
+          cfg.install = ensureArrayTail(cfg.install || [], 'npm install');
 
-          cfg = pruneInstall(cfg)
-          cfg = pruneCache(cfg)
+          cfg = pruneInstall(cfg);
+          cfg = pruneCache(cfg);
 
-          return safeDump(cfg)
+          return safeDump(cfg);
         })
-        .then((data) => fs.writeFile(filePath, data))
-    })
+        .then(data => fs.writeFile(filePath, data));
+    });
 }
 
-function isNeeded ({ cwd } /* : TaskOptions */) {
+function isNeeded({ cwd } /* : TaskOptions */) {
   // free Travis CI requires public GitHub hosting
-  return isPublicGitHub(cwd)
+  return isPublicGitHub(cwd);
 }
 
 module.exports = {
@@ -120,5 +117,5 @@ module.exports = {
   id: path.basename(__filename),
   isNeeded,
   label: LABEL,
-  requires: [ GIT_REPO, PACKAGE_JSON ]
-}
+  requires: [GIT_REPO, PACKAGE_JSON]
+};

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,5 +1,5 @@
 /* @flow */
-'use strict'
+'use strict';
 
 /* ::
 export type Flags = {
@@ -46,3 +46,4 @@ export type Task = {
   settles?: string[]
 }
 */
+

--- a/lib/values.js
+++ b/lib/values.js
@@ -1,31 +1,31 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const chalk = require('chalk')
-const figures = require('figures')
+const chalk = require('chalk');
+const figures = require('figures');
 
-const GIT_REPO = 'GIT_REPO'
-const PACKAGE_JSON = 'PACKAGE_JSON'
-const PACKAGE_JSON_DEVDEPS = 'PACKAGE_JSON_DEVDEPS'
-const PACKAGE_JSON_NAME = 'PACKAGE_JSON_NAME'
-const PROJECT_CODE = 'PROJECT_CODE'
+const GIT_REPO = 'GIT_REPO';
+const PACKAGE_JSON = 'PACKAGE_JSON';
+const PACKAGE_JSON_DEVDEPS = 'PACKAGE_JSON_DEVDEPS';
+const PACKAGE_JSON_NAME = 'PACKAGE_JSON_NAME';
+const PROJECT_CODE = 'PROJECT_CODE';
 
 const JSON_OPTIONS = {
   defaultValue: {},
   indent: 2
-}
+};
 
-const TASK_CHECKING = 'TASK_CHECKING'
-const TASK_DONE = 'TASK_DONE'
-const TASK_SKIPPED = 'TASK_SKIPPED'
-const TASK_WORKING = 'TASK_WORKING'
+const TASK_CHECKING = 'TASK_CHECKING';
+const TASK_DONE = 'TASK_DONE';
+const TASK_SKIPPED = 'TASK_SKIPPED';
+const TASK_WORKING = 'TASK_WORKING';
 
 const TASK_STATUSES = {
   [TASK_CHECKING]: chalk.blue(`CHECKING ${figures.ellipsis}`),
   [TASK_DONE]: chalk.green(`DONE ${figures.tick}`),
   [TASK_SKIPPED]: chalk.gray(`SKIPPED ${figures.cross}`),
   [TASK_WORKING]: chalk.yellow(`WORKING ${figures.play}`)
-}
+};
 
 module.exports = {
   GIT_REPO,
@@ -42,4 +42,4 @@ module.exports = {
   TASK_WORKING,
 
   TASK_STATUSES
-}
+};

--- a/package.json
+++ b/package.json
@@ -42,12 +42,10 @@
   "devDependencies": {
     "ava": "^0.19.0",
     "eslint": "^3.19.0",
-    "eslint-config-standard": "^10.0.0",
     "eslint-plugin-ava": "^4.0.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-node": "^4.2.2",
     "eslint-plugin-promise": "^3.5.0",
-    "eslint-plugin-standard": "^3.0.0",
     "fixpack": "^2.3.1",
     "flow-bin": "^0.44.0",
     "nyc": "^10.0.0"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "eslint-plugin-promise": "^3.5.0",
     "fixpack": "^2.3.1",
     "flow-bin": "^0.44.0",
-    "nyc": "^10.0.0"
+    "nyc": "^10.0.0",
+    "prettier": "^1.2.2"
   },
   "directories": {
     "test": "test"
@@ -75,7 +76,8 @@
     "flow_check": "flow check",
     "nyc": "nyc check-coverage --lines 45",
     "posttest": "npm run eslint && npm run flow_check",
-    "pretest": "npm run fixpack",
-    "test": "npm run ava && npm run nyc"
+    "pretest": "npm run fixpack && npm run prettier",
+    "test": "npm run ava && npm run nyc",
+    "prettier": "prettier --single-quote --write \"{,!(build|coverage|dist|node_modules)/**/}*.js\""
   }
 }

--- a/test/data.js
+++ b/test/data.js
@@ -2,17 +2,7 @@
 
 const test = require('ava')
 
-const { ensureArrayHead, ensureArrayTail } = require('../lib/data.js')
-
-const ensureArrayHeadData = [
-  { args: [ ['a', 'b'], 'c' ], expected: [ 'c', 'a', 'b' ] },
-  { args: [ ['a', 'b'], 'b' ], expected: [ 'b', 'a' ] }
-]
-
-ensureArrayHeadData.forEach((d) => test(
-  `ensureArrayHead(${JSON.stringify(d.args)})`,
-  (t) => t.deepEqual(ensureArrayHead(...d.args), d.expected))
-)
+const { ensureArrayTail } = require('../lib/data.js')
 
 const ensureArrayTailData = [
   { args: [ ['a', 'b'], 'c' ], expected: [ 'a', 'b', 'c' ] },

--- a/test/data.js
+++ b/test/data.js
@@ -1,15 +1,15 @@
-'use strict'
+'use strict';
 
-const test = require('ava')
+const test = require('ava');
 
-const { ensureArrayTail } = require('../lib/data.js')
+const { ensureArrayTail } = require('../lib/data.js');
 
 const ensureArrayTailData = [
-  { args: [ ['a', 'b'], 'c' ], expected: [ 'a', 'b', 'c' ] },
-  { args: [ ['a', 'b'], 'a' ], expected: [ 'b', 'a' ] }
-]
+  { args: [['a', 'b'], 'c'], expected: ['a', 'b', 'c'] },
+  { args: [['a', 'b'], 'a'], expected: ['b', 'a'] }
+];
 
-ensureArrayTailData.forEach((d) => test(
-  `ensureArrayTail(${JSON.stringify(d.args)})`,
-  (t) => t.deepEqual(ensureArrayTail(...d.args), d.expected))
-)
+ensureArrayTailData.forEach(d =>
+  test(`ensureArrayTail(${JSON.stringify(d.args)})`, t =>
+    t.deepEqual(ensureArrayTail(...d.args), d.expected))
+);

--- a/test/git.js
+++ b/test/git.js
@@ -1,79 +1,95 @@
-'use strict'
+'use strict';
 
-const os = require('os')
-const path = require('path')
+const os = require('os');
+const path = require('path');
 
-const fs = require('@jokeyrhyme/pify-fs')
-const pify = require('pify')
-const rimraf = require('rimraf')
-const test = require('ava')
+const fs = require('@jokeyrhyme/pify-fs');
+const pify = require('pify');
+const rimraf = require('rimraf');
+const test = require('ava');
 
 const {
-  getBitbucketPath, getGitHubPath, getOriginUrl,
-  init, isGitClean, isGitProject
-} = require('../lib/git.js')
+  getBitbucketPath,
+  getGitHubPath,
+  getOriginUrl,
+  init,
+  isGitClean,
+  isGitProject
+} = require('../lib/git.js');
 
-test.beforeEach(async (t) => {
-  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'node-init-'))
-  t.context.tempDir = tempDir
-})
+test.beforeEach(async t => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'node-init-'));
+  t.context.tempDir = tempDir;
+});
 
-test.afterEach.always(async (t) => {
-  await pify(rimraf)(t.context.tempDir)
-})
+test.afterEach.always(async t => {
+  await pify(rimraf)(t.context.tempDir);
+});
 
-test('getOriginUrl(cwd) in this project', (t) => getOriginUrl(__dirname)
-  .then((remoteUrl) => {
-    // skip assertions during CI, as they'll fail there :S
-    if (!process.env.CI) {
-      t.truthy(remoteUrl)
-      t.is(typeof remoteUrl, 'string')
-      t.truthy(remoteUrl.includes('github.com'))
-    }
-  })
-  .then(() => t.pass())
-)
+test('getOriginUrl(cwd) in this project', t =>
+  getOriginUrl(__dirname)
+    .then(remoteUrl => {
+      // skip assertions during CI, as they'll fail there :S
+      if (!process.env.CI) {
+        t.truthy(remoteUrl);
+        t.is(typeof remoteUrl, 'string');
+        t.truthy(remoteUrl.includes('github.com'));
+      }
+    })
+    .then(() => t.pass()));
 
 const getBitbucketPathData = [
   { args: [''], expected: '' },
-  { args: ['git@bitbucket.org:username/project.git'], expected: 'username/project' },
-  { args: ['https://username@bitbucket.org/username/project.git'], expected: 'username/project' }
-]
+  {
+    args: ['git@bitbucket.org:username/project.git'],
+    expected: 'username/project'
+  },
+  {
+    args: ['https://username@bitbucket.org/username/project.git'],
+    expected: 'username/project'
+  }
+];
 
-getBitbucketPathData.forEach((d) => test(
-  `getBitbucketPath(${JSON.stringify(d.args)})`,
-  (t) => t.is(getBitbucketPath(...d.args), d.expected)
-))
+getBitbucketPathData.forEach(d =>
+  test(`getBitbucketPath(${JSON.stringify(d.args)})`, t =>
+    t.is(getBitbucketPath(...d.args), d.expected))
+);
 
 const getGitHubPathData = [
   { args: [''], expected: '' },
-  { args: ['git@github.com:username/project.git'], expected: 'username/project' },
-  { args: ['https://github.com/username/project.git'], expected: 'username/project' }
-]
+  {
+    args: ['git@github.com:username/project.git'],
+    expected: 'username/project'
+  },
+  {
+    args: ['https://github.com/username/project.git'],
+    expected: 'username/project'
+  }
+];
 
-getGitHubPathData.forEach((d) => test(
-  `getGitHubPath(${JSON.stringify(d.args)})`,
-  (t) => t.is(getGitHubPath(...d.args), d.expected)
-))
+getGitHubPathData.forEach(d =>
+  test(`getGitHubPath(${JSON.stringify(d.args)})`, t =>
+    t.is(getGitHubPath(...d.args), d.expected))
+);
 
-test('isGitProject(__dirname) is true', async (t) => {
-  const result = await isGitProject(__dirname)
-  t.is(result, true)
-})
+test('isGitProject(__dirname) is true', async t => {
+  const result = await isGitProject(__dirname);
+  t.is(result, true);
+});
 
-test('isGitProject(tempDir) is false', async (t) => {
-  const result = await isGitProject(t.context.tempDir)
-  t.is(result, false)
-})
+test('isGitProject(tempDir) is false', async t => {
+  const result = await isGitProject(t.context.tempDir);
+  t.is(result, false);
+});
 
-test('init(tempDir) then isGitProject(tempDir) is true', async (t) => {
-  await init(t.context.tempDir)
-  const result = await isGitProject(t.context.tempDir)
-  t.is(result, true)
-})
+test('init(tempDir) then isGitProject(tempDir) is true', async t => {
+  await init(t.context.tempDir);
+  const result = await isGitProject(t.context.tempDir);
+  t.is(result, true);
+});
 
-test('init(tempDir) then isGitClean(tempDir) is true', async (t) => {
-  await init(t.context.tempDir)
-  const result = await isGitClean(t.context.tempDir)
-  t.is(result, true)
-})
+test('init(tempDir) then isGitClean(tempDir) is true', async t => {
+  await init(t.context.tempDir);
+  const result = await isGitClean(t.context.tempDir);
+  t.is(result, true);
+});

--- a/test/load-tasks.js
+++ b/test/load-tasks.js
@@ -1,71 +1,69 @@
-'use strict'
+'use strict';
 
-const path = require('path')
+const path = require('path');
 
-const test = require('ava')
+const test = require('ava');
 
-const fs = require('../lib/fs.js')
-const { loadTasks } = require('../lib/tasks.js')
+const fs = require('../lib/fs.js');
+const { loadTasks } = require('../lib/tasks.js');
 
-const TASKS_DIR = path.join(__dirname, '..', 'lib', 'tasks')
+const TASKS_DIR = path.join(__dirname, '..', 'lib', 'tasks');
 
-let tasks, taskIds
+let tasks, taskIds;
 test.before(async () => {
-  tasks = await loadTasks()
-  taskIds = tasks.map((task) => task.id)
-})
+  tasks = await loadTasks();
+  taskIds = tasks.map(task => task.id);
+});
 
-test('loadTasks()', async (t) => {
-  const files = await fs.readdir(TASKS_DIR)
-  t.true(Array.isArray(files))
-  t.is(files.length, tasks.length)
-})
+test('loadTasks()', async t => {
+  const files = await fs.readdir(TASKS_DIR);
+  t.true(Array.isArray(files));
+  t.is(files.length, tasks.length);
+});
 
-test('all tasks have unique "id" and "label"', (t) => {
-  const labels = tasks.map((task) => task.label)
-  const uniqueLabels = Array.from(new Set(labels))
-  t.is(tasks.length, uniqueLabels.length)
+test('all tasks have unique "id" and "label"', t => {
+  const labels = tasks.map(task => task.label);
+  const uniqueLabels = Array.from(new Set(labels));
+  t.is(tasks.length, uniqueLabels.length);
 
-  const ids = tasks.map((task) => task.id)
-  const uniqueIds = Array.from(new Set(ids))
-  t.is(tasks.length, uniqueIds.length)
-})
+  const ids = tasks.map(task => task.id);
+  const uniqueIds = Array.from(new Set(ids));
+  t.is(tasks.length, uniqueIds.length);
+});
 
-test('all tasks "fn" function', (t) => {
-  tasks.forEach((task) => {
-    t.is(typeof task.fn, 'function', task.id)
-  })
-})
+test('all tasks "fn" function', t => {
+  tasks.forEach(task => {
+    t.is(typeof task.fn, 'function', task.id);
+  });
+});
 
-function assertTaskBefore (
+function assertTaskBefore(
   t /* : any */,
   before /* : string */,
   after /* : string[] */
 ) {
-  const ids = [ before, ...after ]
+  const ids = [before, ...after];
 
-  const theseTasks = tasks.filter((task) => ids.includes(task.id))
-  const indices = theseTasks.map((task) => tasks.indexOf(task))
-  t.is(Math.min(...indices), taskIds.indexOf(before))
+  const theseTasks = tasks.filter(task => ids.includes(task.id));
+  const indices = theseTasks.map(task => tasks.indexOf(task));
+  t.is(Math.min(...indices), taskIds.indexOf(before));
 }
 
-test('npm-name.js before tasks that use package.json:name', (t) => {
-  assertTaskBefore(t, 'npm-name.js', [
-    'badge-npm.js'
-  ])
-})
+test('npm-name.js before tasks that use package.json:name', t => {
+  assertTaskBefore(t, 'npm-name.js', ['badge-npm.js']);
+});
 
-test('git-init.js before tasks that use `git` or .git/', (t) => {
+test('git-init.js before tasks that use `git` or .git/', t => {
   assertTaskBefore(t, 'git-init.js', [
     'appveyor.yml.js',
     'badge-appveyor.js',
     'badge-travis.js',
     'npm-init.js',
     'travis.yml'
-  ])
-})
+  ]);
+});
 
-test('npm-init.js before tasks that use package.json', (t) => {
+test('npm-init.js before tasks that use package.json', t => {
   assertTaskBefore(t, 'npm-init.js', [
     'appveyor.yml.js',
     'badge-appveyor.js',
@@ -81,49 +79,51 @@ test('npm-init.js before tasks that use package.json', (t) => {
     'npm-publish-config.js',
     'npm-test.js',
     'travis.yml.js'
-  ])
-})
+  ]);
+});
 
-function assertTaskAfter (
+function assertTaskAfter(
   t /* : any */,
   before /* : string[] */,
   after /* : string */
 ) {
-  const ids = [ ...before, after ]
+  const ids = [...before, after];
 
-  const theseTasks = tasks.filter((task) => ids.includes(task.id))
-  const indices = theseTasks.map((task) => tasks.indexOf(task))
-  t.is(Math.max(...indices), taskIds.indexOf(after))
+  const theseTasks = tasks.filter(task => ids.includes(task.id));
+  const indices = theseTasks.map(task => tasks.indexOf(task));
+  t.is(Math.max(...indices), taskIds.indexOf(after));
 }
 
-test('npm-dev-deps.js after tasks that install devDeps', (t) => {
-  assertTaskAfter(t, [
-    'eslint.js',
-    'fixpack.js',
-    'flowtype.js'
-  ], 'npm-dev-deps.js')
-})
+test('npm-dev-deps.js after tasks that install devDeps', t => {
+  assertTaskAfter(
+    t,
+    ['eslint.js', 'fixpack.js', 'flowtype.js'],
+    'npm-dev-deps.js'
+  );
+});
 
-test('fixpack.js after tasks that use package.json (except npm-dev-deps.js)', (t) => {
-  assertTaskAfter(t, [
-    'appveyor.yml.js',
-    'badge-appveyor.js',
-    'badge-npm.js',
-    'badge-travis.js',
-    'eslint.js',
-    'eslintrc.json.js',
-    'flowtype.js',
-    'npm-engines.js',
-    'npm-init.js',
-    'npm-name.js',
-    'npm-publish-config.js',
-    'npm-test.js',
-    'travis.yml.js'
-  ], 'fixpack.js')
-})
+test('fixpack.js after tasks that use package.json (except npm-dev-deps.js)', t => {
+  assertTaskAfter(
+    t,
+    [
+      'appveyor.yml.js',
+      'badge-appveyor.js',
+      'badge-npm.js',
+      'badge-travis.js',
+      'eslint.js',
+      'eslintrc.json.js',
+      'flowtype.js',
+      'npm-engines.js',
+      'npm-init.js',
+      'npm-name.js',
+      'npm-publish-config.js',
+      'npm-test.js',
+      'travis.yml.js'
+    ],
+    'fixpack.js'
+  );
+});
 
-test('flowtype.js after tasks that edit project code', (t) => {
-  assertTaskAfter(t, [
-    'pkg-main.js'
-  ], 'flowtype.js')
-})
+test('flowtype.js after tasks that edit project code', t => {
+  assertTaskAfter(t, ['pkg-main.js'], 'flowtype.js');
+});

--- a/test/nodejs-versions.js
+++ b/test/nodejs-versions.js
@@ -1,13 +1,13 @@
-'use strict'
+'use strict';
 
-const test = require('ava')
+const test = require('ava');
 
-const { fetchVersions, supportedMajors } = require('../lib/nodejs-versions.js')
+const { fetchVersions, supportedMajors } = require('../lib/nodejs-versions.js');
 
-test('fetchVersions()', async (t) => {
-  const versions = await fetchVersions()
-  t.true(Array.isArray(versions))
-})
+test('fetchVersions()', async t => {
+  const versions = await fetchVersions();
+  t.true(Array.isArray(versions));
+});
 
 const versions20161019 = [
   { version: 'v6.9.1' },
@@ -17,22 +17,19 @@ const versions20161019 = [
   { version: 'v3.0.0' },
   { version: 'v2.0.0' },
   { version: 'v1.0.0' }
-]
+];
 
-const versions20161025 = [
-  { version: 'v7.0.0' },
-  ...versions20161019
-]
+const versions20161025 = [{ version: 'v7.0.0' }, ...versions20161019];
 
 const supportedMajorsData = [
-  { range: '>=2', versions: versions20161019, expected: [ 2, 4, 6 ] },
-  { range: '>=2', versions: versions20161025, expected: [ 2, 4, 6, 7 ] },
-  { range: '>=4', versions: versions20161019, expected: [ 4, 6 ] },
-  { range: '>=4', versions: versions20161025, expected: [ 4, 6, 7 ] }
-]
+  { range: '>=2', versions: versions20161019, expected: [2, 4, 6] },
+  { range: '>=2', versions: versions20161025, expected: [2, 4, 6, 7] },
+  { range: '>=4', versions: versions20161019, expected: [4, 6] },
+  { range: '>=4', versions: versions20161025, expected: [4, 6, 7] }
+];
 supportedMajorsData.forEach(({ range, versions, expected }) => {
-  const latestVersion = versions[0].version
-  test(`supportedMajors() ${range} ${latestVersion}`, (t) => {
-    t.deepEqual(supportedMajors(range, versions), expected)
-  })
-})
+  const latestVersion = versions[0].version;
+  test(`supportedMajors() ${range} ${latestVersion}`, t => {
+    t.deepEqual(supportedMajors(range, versions), expected);
+  });
+});

--- a/test/pkg.js
+++ b/test/pkg.js
@@ -1,17 +1,17 @@
-'use strict'
+'use strict';
 
-const path = require('path')
+const path = require('path');
 
-const test = require('ava')
+const test = require('ava');
 
-const { getScope, injectScope, isReactProject } = require('../lib/pkg.js')
+const { getScope, injectScope, isReactProject } = require('../lib/pkg.js');
 
-function shortCwd (cwd) {
-  return `.../${path.basename(cwd || '')}`
+function shortCwd(cwd) {
+  return `.../${path.basename(cwd || '')}`;
 }
 
-function fixturePath (name) {
-  return path.join(__dirname, 'fixtures', name)
+function fixturePath(name) {
+  return path.join(__dirname, 'fixtures', name);
 }
 
 const getScopeData = [
@@ -22,13 +22,12 @@ const getScopeData = [
   { cwd: fixturePath('named'), scope: '', expected: '' },
   { cwd: fixturePath('scoped'), scope: '', expected: 'myscope' },
   { cwd: fixturePath('scoped'), scope: 'org', expected: 'org' }
-]
+];
 
-getScopeData.forEach((d) => test(
-  `getScope("${shortCwd(d.cwd)}", "${d.scope}")`,
-  (t) => getScope(d.cwd, d.scope)
-    .then((scope) => t.is(scope, d.expected))
-))
+getScopeData.forEach(d =>
+  test(`getScope("${shortCwd(d.cwd)}", "${d.scope}")`, t =>
+    getScope(d.cwd, d.scope).then(scope => t.is(scope, d.expected)))
+);
 
 const injectScopeData = [
   { args: ['', ''], expected: '' },
@@ -36,25 +35,37 @@ const injectScopeData = [
   { args: ['new', 'name'], expected: '@new/name' },
   { args: ['', '@org/name'], expected: '@org/name' },
   { args: ['new', '@org/name'], expected: '@new/name' }
-]
+];
 
-injectScopeData.forEach((d) => test(
-  `injectScope(${JSON.stringify(d.args)})`,
-  (t) => t.is(injectScope(...d.args), d.expected)
-))
+injectScopeData.forEach(d =>
+  test(`injectScope(${JSON.stringify(d.args)})`, t =>
+    t.is(injectScope(...d.args), d.expected))
+);
 
 /* :: import type { PackageJSON, ReactProjectData } from '../lib/types.js' */
 
 const isReactProjectData /* : Array<ReactProjectData> */ = [
   { pkg: { name: 'a', version: '1' }, expected: false },
   { pkg: { name: 'a', version: '1', dependencies: {} }, expected: false },
-  { pkg: { name: 'a', version: '1', dependencies: { react: '*' } }, expected: true },
-  { pkg: { name: 'a', version: '1', devDependencies: { react: '*' } }, expected: true },
-  { pkg: { name: 'a', version: '1', devDependencies: { 'react-scripts': '*' } }, expected: true },
-  { pkg: { name: 'a', version: '1', peerDependencies: { react: '*' } }, expected: true }
-]
+  {
+    pkg: { name: 'a', version: '1', dependencies: { react: '*' } },
+    expected: true
+  },
+  {
+    pkg: { name: 'a', version: '1', devDependencies: { react: '*' } },
+    expected: true
+  },
+  {
+    pkg: { name: 'a', version: '1', devDependencies: { 'react-scripts': '*' } },
+    expected: true
+  },
+  {
+    pkg: { name: 'a', version: '1', peerDependencies: { react: '*' } },
+    expected: true
+  }
+];
 
-isReactProjectData.forEach((d) => test(
-  `isReactProject(${JSON.stringify(d.pkg)})`,
-  (t) => t.is(isReactProject(d.pkg), d.expected)
-))
+isReactProjectData.forEach(d =>
+  test(`isReactProject(${JSON.stringify(d.pkg)})`, t =>
+    t.is(isReactProject(d.pkg), d.expected))
+);

--- a/test/sort-tasks.js
+++ b/test/sort-tasks.js
@@ -1,72 +1,72 @@
-'use strict'
+'use strict';
 
-const test = require('ava')
+const test = require('ava');
 
-const { compareByMetadata } = require('../lib/tasks.js')
+const { compareByMetadata } = require('../lib/tasks.js');
 
-const noop = () => Promise.resolve()
+const noop = () => Promise.resolve();
 
-test('tasks without metadata', (t) => {
+test('tasks without metadata', t => {
   const tasks = [
     { fn: noop, id: 'a', label: 'a' },
     { fn: noop, id: 'b', label: 'b' },
     { fn: noop, id: 'c', label: 'c' }
-  ]
-  t.notThrows(() => tasks.sort(compareByMetadata))
-})
+  ];
+  t.notThrows(() => tasks.sort(compareByMetadata));
+});
 
-test('2x "provides: FOO" and 1x "requires: FOO"', (t) => {
+test('2x "provides: FOO" and 1x "requires: FOO"', t => {
   const tasks = [
-    { fn: noop, id: 'a', label: 'a', provides: [ 'FOO' ] },
-    { fn: noop, id: 'b', label: 'b', requires: [ 'FOO' ] },
-    { fn: noop, id: 'c', label: 'c', provides: [ 'FOO' ] }
-  ]
-  t.notThrows(() => tasks.sort(compareByMetadata))
-  const ids = tasks.map((task) => task.id)
-  t.deepEqual(ids, [ 'a', 'c', 'b' ])
-})
+    { fn: noop, id: 'a', label: 'a', provides: ['FOO'] },
+    { fn: noop, id: 'b', label: 'b', requires: ['FOO'] },
+    { fn: noop, id: 'c', label: 'c', provides: ['FOO'] }
+  ];
+  t.notThrows(() => tasks.sort(compareByMetadata));
+  const ids = tasks.map(task => task.id);
+  t.deepEqual(ids, ['a', 'c', 'b']);
+});
 
-test('1x "provides: FOO" and 2x "requires: FOO"', (t) => {
+test('1x "provides: FOO" and 2x "requires: FOO"', t => {
   const tasks = [
-    { fn: noop, id: 'a', label: 'a', requires: [ 'FOO' ] },
-    { fn: noop, id: 'b', label: 'b', requires: [ 'FOO' ] },
-    { fn: noop, id: 'c', label: 'c', provides: [ 'FOO' ] }
-  ]
-  t.notThrows(() => tasks.sort(compareByMetadata))
-  const ids = tasks.map((task) => task.id)
-  t.deepEqual(ids, [ 'c', 'a', 'b' ])
-})
+    { fn: noop, id: 'a', label: 'a', requires: ['FOO'] },
+    { fn: noop, id: 'b', label: 'b', requires: ['FOO'] },
+    { fn: noop, id: 'c', label: 'c', provides: ['FOO'] }
+  ];
+  t.notThrows(() => tasks.sort(compareByMetadata));
+  const ids = tasks.map(task => task.id);
+  t.deepEqual(ids, ['c', 'a', 'b']);
+});
 
-test('2x "provides: FOO" and 1x "settles: FOO"', (t) => {
+test('2x "provides: FOO" and 1x "settles: FOO"', t => {
   const tasks = [
-    { fn: noop, id: 'a', label: 'a', provides: [ 'FOO' ] },
-    { fn: noop, id: 'b', label: 'b', settles: [ 'FOO' ] },
-    { fn: noop, id: 'c', label: 'c', provides: [ 'FOO' ] }
-  ]
-  t.notThrows(() => tasks.sort(compareByMetadata))
-  const ids = tasks.map((task) => task.id)
-  t.deepEqual(ids, [ 'a', 'c', 'b' ])
-})
+    { fn: noop, id: 'a', label: 'a', provides: ['FOO'] },
+    { fn: noop, id: 'b', label: 'b', settles: ['FOO'] },
+    { fn: noop, id: 'c', label: 'c', provides: ['FOO'] }
+  ];
+  t.notThrows(() => tasks.sort(compareByMetadata));
+  const ids = tasks.map(task => task.id);
+  t.deepEqual(ids, ['a', 'c', 'b']);
+});
 
-test('"provides: FOO" and "requires: FOO" and "settles: FOO"', (t) => {
+test('"provides: FOO" and "requires: FOO" and "settles: FOO"', t => {
   const tasks = [
-    { fn: noop, id: 'a', label: 'a', settles: [ 'FOO' ] },
-    { fn: noop, id: 'b', label: 'b', requires: [ 'FOO' ] },
-    { fn: noop, id: 'c', label: 'c', provides: [ 'FOO' ] }
-  ]
-  t.notThrows(() => tasks.sort(compareByMetadata))
-  const ids = tasks.map((task) => task.id)
-  t.deepEqual(ids, [ 'c', 'b', 'a' ])
-})
+    { fn: noop, id: 'a', label: 'a', settles: ['FOO'] },
+    { fn: noop, id: 'b', label: 'b', requires: ['FOO'] },
+    { fn: noop, id: 'c', label: 'c', provides: ['FOO'] }
+  ];
+  t.notThrows(() => tasks.sort(compareByMetadata));
+  const ids = tasks.map(task => task.id);
+  t.deepEqual(ids, ['c', 'b', 'a']);
+});
 
-test('A, A->B, B->C, BC->end', (t) => {
+test('A, A->B, B->C, BC->end', t => {
   const tasks = [
-    { fn: noop, id: 'a', label: 'a', requires: [ 'B', 'C' ] },
-    { fn: noop, id: 'b', label: 'b', provides: [ 'C' ], requires: [ 'B' ] },
-    { fn: noop, id: 'c', label: 'c', provides: [ 'B' ], requires: [ 'A' ] },
-    { fn: noop, id: 'd', label: 'd', provides: [ 'A' ] }
-  ]
-  t.notThrows(() => tasks.sort(compareByMetadata))
-  const ids = tasks.map((task) => task.id)
-  t.deepEqual(ids, [ 'd', 'c', 'b', 'a' ])
-})
+    { fn: noop, id: 'a', label: 'a', requires: ['B', 'C'] },
+    { fn: noop, id: 'b', label: 'b', provides: ['C'], requires: ['B'] },
+    { fn: noop, id: 'c', label: 'c', provides: ['B'], requires: ['A'] },
+    { fn: noop, id: 'd', label: 'd', provides: ['A'] }
+  ];
+  t.notThrows(() => tasks.sort(compareByMetadata));
+  const ids = tasks.map(task => task.id);
+  t.deepEqual(ids, ['d', 'c', 'b', 'a']);
+});

--- a/test/tasks-eslintrc-json.js
+++ b/test/tasks-eslintrc-json.js
@@ -6,14 +6,13 @@ const test = require('ava')
 const { lib: { testEslintrcUpdater } } = require('../lib/tasks/eslintrc.json.js')
 
 test('fresh test/.eslintrc.json', (t) => {
-  const result = testEslintrcUpdater({}, { hasReact: false })
+  const result = testEslintrcUpdater({})
   t.is(result.extends, undefined)
 })
 
 test('old test/.eslintrc.json', (t) => {
   const result = testEslintrcUpdater(
-    { extends: [ '../.eslintrc.json' ] },
-    { hasReact: false }
+    { extends: [ '../.eslintrc.json' ] }
   )
   t.is(result.extends, undefined)
 })

--- a/test/tasks-eslintrc-json.js
+++ b/test/tasks-eslintrc-json.js
@@ -1,18 +1,18 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const test = require('ava')
+const test = require('ava');
 
-const { lib: { testEslintrcUpdater } } = require('../lib/tasks/eslintrc.json.js')
+const {
+  lib: { testEslintrcUpdater }
+} = require('../lib/tasks/eslintrc.json.js');
 
-test('fresh test/.eslintrc.json', (t) => {
-  const result = testEslintrcUpdater({})
-  t.is(result.extends, undefined)
-})
+test('fresh test/.eslintrc.json', t => {
+  const result = testEslintrcUpdater({});
+  t.is(result.extends, undefined);
+});
 
-test('old test/.eslintrc.json', (t) => {
-  const result = testEslintrcUpdater(
-    { extends: [ '../.eslintrc.json' ] }
-  )
-  t.is(result.extends, undefined)
-})
+test('old test/.eslintrc.json', t => {
+  const result = testEslintrcUpdater({ extends: ['../.eslintrc.json'] });
+  t.is(result.extends, undefined);
+});

--- a/test/tasks-greenkeeper.js
+++ b/test/tasks-greenkeeper.js
@@ -1,16 +1,16 @@
 /* @flow */
-'use strict'
+'use strict';
 
-const test = require('ava')
+const test = require('ava');
 
-const { pkgUpdater } = require('../lib/tasks/greenkeeper.js')
+const { pkgUpdater } = require('../lib/tasks/greenkeeper.js');
 
-test('fresh package.json', (t) => {
-  const result = pkgUpdater({ name: 'my-package', version: '1.2.3' })
-  t.deepEqual(result, { name: 'my-package', version: '1.2.3' })
-})
+test('fresh package.json', t => {
+  const result = pkgUpdater({ name: 'my-package', version: '1.2.3' });
+  t.deepEqual(result, { name: 'my-package', version: '1.2.3' });
+});
 
-test('old package.json', (t) => {
+test('old package.json', t => {
   const result = pkgUpdater({
     name: 'my-package',
     version: '1.2.3',
@@ -22,7 +22,7 @@ test('old package.json', (t) => {
       postpublish: 'greenkeeper-postpublish',
       test: 'exit 0'
     }
-  })
+  });
   t.deepEqual(result, {
     name: 'my-package',
     version: '1.2.3',
@@ -32,5 +32,5 @@ test('old package.json', (t) => {
     scripts: {
       test: 'exit 0'
     }
-  })
-})
+  });
+});


### PR DESCRIPTION
### Added

-   use [prettier](https://github.com/prettier/prettier) for JavaScript code style

-   [recommended React rules for ESLint](https://github.com/yannickcr/eslint-plugin-react) for React projects


### Removed

-   [JavaScript SemiStandard Style for ESLint](https://github.com/Flet/eslint-config-semistandard)

-   [JavaScript Standard Style for ESLint](https://github.com/feross/eslint-config-standard)

  -   [JavaScript Standard Style Plugin for ESLint](https://github.com/xjamundx/eslint-plugin-standard)

-   [JavaScript Standard JSX Style for ESLint](https://github.com/feross/eslint-config-standard-jsx)

-   [JavaScript Standard React Style for ESLint](https://github.com/feross/eslint-config-standard-react)


### Notes

-   (fixes #110)