### PR TITLE
fixpack in "pretest"; better detection of test/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 -   ensure package "main" points to file (created for you, if not)
 
 
+### Fixed
+
+-   support .eslintrc.json file in `test/`, `tests/`, or `__tests__/` instead of always assuming `test/`
+
+
 ## 1.9.1 - 2017-03-06
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 -   ensure package "main" points to file (created for you, if not)
 
 
+### Changed
+
+-   `npm run fixpack` is now part of the "pretest" hook rather than "posttest"
+
+
 ### Fixed
 
 -   support .eslintrc.json file in `test/`, `tests/`, or `__tests__/` instead of always assuming `test/`

--- a/lib/pkg.js
+++ b/lib/pkg.js
@@ -4,11 +4,28 @@
 const path = require('path')
 
 const loadJson = require('load-json-file')
+const union = require('lodash.union')
+const without = require('lodash.without')
 
 const MATCH_SCOPE_REGEXP = /^@(\w[\w_.-]*)\//
 const SCOPED_REGEXP = /^@(\w[\w_.-]*)\/(\w[\w_.-]*)$/
 
 /* :: import type { PackageJSON, PackageJSONDependencies } from './types.js' */
+
+function addScript (
+  pkg /* : PackageJSON */,
+  name /* : string */,
+  value /* : string */
+) {
+  const scripts = pkg.scripts || {}
+
+  let values = (scripts[name] || '').split(' && ')
+  values = values.filter((v) => !!v) // drop empties
+  values = union(values, [ value ])
+  scripts[name] = values.join(' && ')
+
+  pkg.scripts = scripts
+}
 
 function getPkg (cwd /* : string */) /* : Promise<PackageJSON> */ {
   return loadJson(path.join(cwd, 'package.json'))
@@ -57,9 +74,30 @@ function isReactProject (
   )
 }
 
+function removeScript (
+  pkg /* : PackageJSON */,
+  name /* : string */,
+  value /* : string */
+) {
+  const scripts = pkg.scripts || {}
+
+  let values = (scripts[name] || '').split(' && ')
+  values = values.filter((pt) => !!pt) // drop empties
+  values = without(values, value)
+  if (values.length) {
+    scripts[name] = values.join(' && ')
+  } else {
+    delete scripts[name]
+  }
+
+  pkg.scripts = scripts
+}
+
 module.exports = {
+  addScript,
   getPkg,
   getScope,
   injectScope,
-  isReactProject
+  isReactProject,
+  removeScript
 }

--- a/lib/tasks/eslintrc.json.js
+++ b/lib/tasks/eslintrc.json.js
@@ -77,7 +77,11 @@ function eslintrc (cwd) {
   ]
   const testRcPaths = [
     path.join(cwd, 'test', '.eslintrc'),
-    path.join(cwd, 'test', '.eslintrc.json')
+    path.join(cwd, 'test', '.eslintrc.json'),
+    path.join(cwd, 'tests', '.eslintrc'),
+    path.join(cwd, 'tests', '.eslintrc.json'),
+    path.join(cwd, '__tests__', '.eslintrc'),
+    path.join(cwd, '__tests__', '.eslintrc.json')
   ]
   let hasReact = false
   return getPkg(cwd)

--- a/lib/tasks/fixpack.js
+++ b/lib/tasks/fixpack.js
@@ -6,28 +6,28 @@ const path = require('path')
 const execa = require('execa')
 const updateJsonFile = require('update-json-file')
 
-const { getPkg } = require('../pkg.js')
-const { JSON_OPTIONS, PACKAGE_JSON, PACKAGE_JSON_DEVDEPS } = require('../values.js')
+const { addScript, removeScript } = require('../pkg.js')
+const {
+  JSON_OPTIONS, PACKAGE_JSON, PACKAGE_JSON_DEVDEPS
+} = require('../values.js')
 
 const LABEL = 'fixpack installed and configured'
 
 function npmInstall (cwd) {
-  return getPkg(cwd)
-    .then(({ devDependencies }) => {
-      const devDeps = Object.keys(devDependencies || {})
-      if (!devDeps.includes('fixpack')) {
-        return execa('npm', [
-          'install', '--save-dev',
-          'fixpack'
-        ], { cwd })
-      }
-    })
+  return execa('npm', [
+    'install', '--save-dev',
+    'fixpack'
+  ], { cwd })
 }
 
 function npmScript (cwd) {
   return updateJsonFile(path.join(cwd, 'package.json'), (pkg) => {
     pkg.scripts = pkg.scripts || {}
     pkg.scripts.fixpack = 'fixpack'
+
+    addScript(pkg, 'pretest', 'npm run fixpack')
+    removeScript(pkg, 'posttest', 'npm run fixpack')
+
     return pkg
   }, JSON_OPTIONS)
 }

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "fixpack": "fixpack",
     "flow_check": "flow check",
     "nyc": "nyc check-coverage --lines 45",
-    "posttest": "npm run eslint && npm run flow_check && npm run fixpack",
-    "test": "npm run ava && npm run nyc"
+    "posttest": "npm run eslint && npm run flow_check",
+    "test": "npm run ava && npm run nyc",
+    "pretest": "npm run fixpack"
   }
 }


### PR DESCRIPTION
### Changed

-   `npm run fixpack` is now part of the "pretest" hook rather than "posttest"


### Fixed

-   support .eslintrc.json file in `test/`, `tests/`, or `__tests__/` instead of always assuming `test/`
