### PR TITLE
install and configure jest if other test frameworks are absent ...

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,6 @@
+
+build
+
+coverage
+
+dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 -   move ESLint to "pretest" script, as it may change files (#117)
 
+-   dot-ignore files (e.g. .gitignore) use UNIX line-endings
+
 
 ## 2.0.0 - 2017-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 -   install and configure [jest](https://github.com/facebook/jest) if other test frameworks are absent and `npm test` is not configured
 
+-   populate a ".eslintignore" file to configure ESLint
+
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 ## Unreleased
 
 
+### Changed
+
+-   example entry-point "index.js" file no longer enables Flow by default
+
+
 ## 2.0.0 - 2017-04-23
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 -   example entry-point "index.js" file no longer enables Flow by default
 
+-   move ESLint to "pretest" script, as it may change files (#117)
+
 
 ## 2.0.0 - 2017-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 ## Unreleased
 
 
+### Added
+
+-   install and configure [jest](https://github.com/facebook/jest) if other test frameworks are absent and `npm test` is not configured
+
+
 ### Changed
 
 -   example entry-point "index.js" file no longer enables Flow by default

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ node-init --help
 
 -   installs and configures [ESLint](http://eslint.org/), with [eslint-plugin-node](https://github.com/mysticatea/eslint-plugin-node)
 
+-   install and configure [jest](https://github.com/facebook/jest) if other test frameworks are absent and `npm test` is not configured
+
 -   adds an `npm run eslint` script for ESLint
 
 -   installs and configures [FlowType](https://flowtype.org/) and `npm run flow_check`

--- a/README.md
+++ b/README.md
@@ -99,3 +99,8 @@ node-init --help
 -   copies [.editorconfig](http://editorconfig.org/) from [multi-lingual template config](https://github.com/jokeyrhyme/standard-editorconfig)
 
 -   ensures jsconfig.json for [Visual Studio Code](https://code.visualstudio.com/) exists
+
+
+### Other Opinionated Stuff
+
+-   for simplicity, text files should use UNIX line-endings

--- a/lib/pkg.js
+++ b/lib/pkg.js
@@ -3,6 +3,7 @@
 
 const path = require('path');
 
+const intersection = require('lodash.intersection');
 const loadJson = require('load-json-file');
 const union = require('lodash.union');
 const without = require('lodash.without');
@@ -47,6 +48,24 @@ function getScope(cwd /* : string */, scope /* : string */) {
   });
 }
 
+function hasTestFramework(
+  { devDependencies = {} } /* : PackageJSON */
+) /* : boolean */ {
+  return (
+    intersection(Object.keys(devDependencies), [
+      'ava',
+      'jasmine',
+      'jest',
+      'lab',
+      'mocha',
+      'qunit',
+      'qunitjs',
+      'tap',
+      'tape'
+    ]).length > 0
+  );
+}
+
 function injectScope(scope /* : string */, name /* : string */) {
   const [, currentScope, currentName] = name.match(SCOPED_REGEXP) || [];
   if (currentScope && currentName) {
@@ -74,6 +93,11 @@ function isReactProject(
     peerDependencies.react);
 }
 
+function isTestScriptUnconfigured({ scripts = {} } /* : PackageJSON */) {
+  const NPM_INIT_TEST = 'echo "Error: no test specified" && exit 1';
+  return !scripts.test || scripts.test === NPM_INIT_TEST;
+}
+
 function removeScript(
   pkg /* : PackageJSON */,
   name /* : string */,
@@ -97,7 +121,9 @@ module.exports = {
   addScript,
   getPkg,
   getScope,
+  hasTestFramework,
   injectScope,
   isReactProject,
+  isTestScriptUnconfigured,
   removeScript
 };

--- a/lib/skeleton/index.js
+++ b/lib/skeleton/index.js
@@ -1,4 +1,3 @@
-/* @flow */
 'use strict';
 
 module.exports = {};

--- a/lib/tasks/ava.js
+++ b/lib/tasks/ava.js
@@ -4,7 +4,7 @@
 const path = require('path');
 const updateJsonFile = require('update-json-file');
 
-const { getPkg } = require('../pkg.js');
+const { addScript, getPkg } = require('../pkg.js');
 const { JSON_OPTIONS, PACKAGE_JSON } = require('../values.js');
 
 const LABEL = 'ava found and configured';
@@ -17,9 +17,8 @@ function fn({ cwd } /* : TaskOptions */) {
     pkg => {
       const devDeps = pkg.devDependencies || {};
       if (devDeps.ava) {
-        pkg.scripts = Object.assign({}, pkg.scripts, {
-          ava: 'ava'
-        });
+        addScript(pkg, 'ava', 'ava');
+
         if (devDeps.nyc) {
           pkg.scripts = Object.assign({}, pkg.scripts, {
             ava: 'nyc ava',

--- a/lib/tasks/ava.js
+++ b/lib/tasks/ava.js
@@ -4,9 +4,10 @@
 const path = require('path');
 const updateJsonFile = require('update-json-file');
 
+const { getPkg } = require('../pkg.js');
 const { JSON_OPTIONS, PACKAGE_JSON } = require('../values.js');
 
-const LABEL = '`npm test` executes installed test runners';
+const LABEL = 'ava found and configured';
 
 /* :: import type { TaskOptions } from '../types.js' */
 
@@ -27,36 +28,20 @@ function fn({ cwd } /* : TaskOptions */) {
         }
       }
 
-      if (devDeps.jest) {
-        pkg.scripts = Object.assign({}, pkg.scripts, {
-          jest: 'jest'
-        });
-        pkg.jest = Object.assign({}, pkg.jest, {
-          collectCoverage: true,
-          coverageThreshold: {
-            global: {
-              lines: 90
-            }
-          },
-          testRegex: '/__tests__/[^\\/]*\\.js$'
-        });
-      }
-
-      if (devDeps.mocha) {
-        pkg.scripts = Object.assign({}, pkg.scripts, {
-          mocha: 'mocha'
-        });
-      }
-
       return pkg;
     },
     JSON_OPTIONS
   );
 }
 
+function isNeeded({ cwd } /* : TaskOptions */) {
+  return getPkg(cwd).then(pkg => !!(pkg.devDependencies || {}).ava);
+}
+
 module.exports = {
   fn,
   id: path.basename(__filename),
+  isNeeded,
   label: LABEL,
   requires: [PACKAGE_JSON]
 };

--- a/lib/tasks/eslint.js
+++ b/lib/tasks/eslint.js
@@ -6,7 +6,12 @@ const path = require('path');
 const execa = require('execa');
 const updateJsonFile = require('update-json-file');
 
-const { getPkg, isReactProject } = require('../pkg.js');
+const {
+  addScript,
+  getPkg,
+  isReactProject,
+  removeScript
+} = require('../pkg.js');
 const {
   JSON_OPTIONS,
   PACKAGE_JSON,
@@ -41,8 +46,15 @@ function npmScript(cwd) {
   return updateJsonFile(
     path.join(cwd, 'package.json'),
     pkg => {
-      pkg.scripts = pkg.scripts || {};
-      pkg.scripts.eslint = 'eslint --fix --cache .';
+      addScript(pkg, 'eslint', 'eslint --fix --cache .');
+
+      // call ESLint from "pretest", because `--fix` may change files
+      addScript(pkg, 'pretest', 'npm run eslint');
+
+      // do not call ESLint from "posttest" or "test"
+      removeScript(pkg, 'posttest', 'npm run eslint');
+      removeScript(pkg, 'test', 'npm run eslint');
+
       return pkg;
     },
     JSON_OPTIONS

--- a/lib/tasks/eslintignore.js
+++ b/lib/tasks/eslintignore.js
@@ -1,0 +1,53 @@
+/* @flow */
+'use strict';
+
+const os = require('os');
+const path = require('path');
+
+const through2 = require('through2');
+const vfs = require('vinyl-fs');
+
+const fs = require('../fs.js');
+
+const LABEL = '.eslintignore populated';
+const FILENAME = '.eslintignore';
+
+/* :: import type { TaskOptions } from '../types.js' */
+
+const IGNORES = ['build', 'coverage', 'dist'];
+
+function fn({ cwd } /* : TaskOptions */) {
+  return fs.touch(path.join(cwd, FILENAME)).then(
+    () =>
+      new Promise((resolve, reject) => {
+        vfs
+          .src(FILENAME, { cwd })
+          .pipe(
+            through2.obj((file, enc, cb) => {
+              let contents = file.contents.toString(enc);
+
+              for (const entry of IGNORES) {
+                if (
+                  !contents.includes(`\n${entry}\n`) &&
+                  !contents.includes(`\r\n${entry}\r\n`)
+                ) {
+                  contents += `${os.EOL}${entry}${os.EOL}`;
+                }
+              }
+
+              file.contents = Buffer.from(contents, enc);
+              cb(null, file);
+            })
+          )
+          .pipe(vfs.dest(cwd))
+          .on('error', err => reject(err))
+          .on('end', () => resolve());
+      })
+  );
+}
+
+module.exports = {
+  fn,
+  id: path.basename(__filename),
+  label: LABEL
+};

--- a/lib/tasks/eslintignore.js
+++ b/lib/tasks/eslintignore.js
@@ -1,13 +1,13 @@
 /* @flow */
 'use strict';
 
-const os = require('os');
 const path = require('path');
 
 const through2 = require('through2');
 const vfs = require('vinyl-fs');
 
 const fs = require('../fs.js');
+const { withLine } = require('../text.js');
 
 const LABEL = '.eslintignore populated';
 const FILENAME = '.eslintignore';
@@ -27,12 +27,7 @@ function fn({ cwd } /* : TaskOptions */) {
               let contents = file.contents.toString(enc);
 
               for (const entry of IGNORES) {
-                if (
-                  !contents.includes(`\n${entry}\n`) &&
-                  !contents.includes(`\r\n${entry}\r\n`)
-                ) {
-                  contents += `${os.EOL}${entry}${os.EOL}`;
-                }
+                contents = withLine(contents, entry);
               }
 
               file.contents = Buffer.from(contents, enc);

--- a/lib/tasks/gitignore.js
+++ b/lib/tasks/gitignore.js
@@ -1,33 +1,35 @@
 /* @flow */
 'use strict';
 
-const os = require('os');
 const path = require('path');
 
 const through2 = require('through2');
 const vfs = require('vinyl-fs');
 
 const fs = require('../fs.js');
+const { withLine } = require('../text.js');
 
 const LABEL = '.gitignore set for Node.js';
+
+const IGNORES = ['.eslintcache', 'node_modules'];
+const FILENAME = '.gitignore';
 
 /* :: import type { TaskOptions } from '../types.js' */
 
 function fn({ cwd } /* : TaskOptions */) {
-  return fs.touch(path.join(cwd, '.gitignore')).then(
+  return fs.touch(path.join(cwd, FILENAME)).then(
     () =>
       new Promise((resolve, reject) => {
         vfs
-          .src('.gitignore', { cwd })
+          .src(FILENAME, { cwd })
           .pipe(
             through2.obj((file, enc, cb) => {
               let contents = file.contents.toString(enc);
-              if (!/\bnode_modules\b/.test(contents)) {
-                contents += `${os.EOL}node_modules${os.EOL}`;
+
+              for (const entry of IGNORES) {
+                contents = withLine(contents, entry);
               }
-              if (!/\.eslintcache\b/.test(contents)) {
-                contents += `${os.EOL}.eslintcache${os.EOL}`;
-              }
+
               file.contents = Buffer.from(contents, enc);
               cb(null, file);
             })

--- a/lib/tasks/jest.js
+++ b/lib/tasks/jest.js
@@ -1,0 +1,49 @@
+/* @flow */
+'use strict';
+
+const path = require('path');
+const updateJsonFile = require('update-json-file');
+
+const { getPkg } = require('../pkg.js');
+const { JSON_OPTIONS, PACKAGE_JSON } = require('../values.js');
+
+const LABEL = 'jest found and configured';
+
+/* :: import type { TaskOptions } from '../types.js' */
+
+function fn({ cwd } /* : TaskOptions */) {
+  return updateJsonFile(
+    path.join(cwd, 'package.json'),
+    pkg => {
+      const devDeps = pkg.devDependencies || {};
+      if (devDeps.jest) {
+        pkg.scripts = Object.assign({}, pkg.scripts, {
+          jest: 'jest'
+        });
+        pkg.jest = Object.assign({}, pkg.jest, {
+          collectCoverage: true,
+          coverageThreshold: {
+            global: {
+              lines: 90
+            }
+          }
+        });
+      }
+
+      return pkg;
+    },
+    JSON_OPTIONS
+  );
+}
+
+function isNeeded({ cwd } /* : TaskOptions */) {
+  return getPkg(cwd).then(pkg => !!(pkg.devDependencies || {}).jest);
+}
+
+module.exports = {
+  fn,
+  id: path.basename(__filename),
+  isNeeded,
+  label: LABEL,
+  requires: [PACKAGE_JSON]
+};

--- a/lib/tasks/jest.js
+++ b/lib/tasks/jest.js
@@ -4,31 +4,42 @@
 const path = require('path');
 const updateJsonFile = require('update-json-file');
 
-const { getPkg } = require('../pkg.js');
+const execa = require('execa');
+
+const {
+  addScript,
+  getPkg,
+  hasTestFramework,
+  isTestScriptUnconfigured,
+  removeScript
+} = require('../pkg.js');
 const { JSON_OPTIONS, PACKAGE_JSON } = require('../values.js');
 
-const LABEL = 'jest found and configured';
+const LABEL = 'jest installed and configured';
 
-/* :: import type { TaskOptions } from '../types.js' */
+function npmInstall(cwd) {
+  return execa('npm', ['install', '--save-dev', 'jest'], { cwd });
+}
 
-function fn({ cwd } /* : TaskOptions */) {
+function editPackageJson(cwd) {
   return updateJsonFile(
     path.join(cwd, 'package.json'),
     pkg => {
-      const devDeps = pkg.devDependencies || {};
-      if (devDeps.jest) {
-        pkg.scripts = Object.assign({}, pkg.scripts, {
-          jest: 'jest'
-        });
-        pkg.jest = Object.assign({}, pkg.jest, {
-          collectCoverage: true,
-          coverageThreshold: {
-            global: {
-              lines: 90
-            }
+      addScript(pkg, 'jest', 'jest');
+      addScript(pkg, 'test', 'npm run jest'); // `npm test` runs jest
+
+      pkg.jest = Object.assign({}, pkg.jest, {
+        collectCoverage: true,
+        coverageThreshold: {
+          global: {
+            lines: 90
           }
-        });
-      }
+        }
+      });
+
+      // remove unconfigured `npm test` provided by `npm init -y`
+      removeScript(pkg, 'test', 'echo "Error: no test specified"');
+      removeScript(pkg, 'test', 'exit 1');
 
       return pkg;
     },
@@ -36,8 +47,18 @@ function fn({ cwd } /* : TaskOptions */) {
   );
 }
 
+/* :: import type { TaskOptions } from '../types.js' */
+
+function fn({ cwd } /* : TaskOptions */) {
+  return npmInstall(cwd).then(() => editPackageJson(cwd));
+}
+
 function isNeeded({ cwd } /* : TaskOptions */) {
-  return getPkg(cwd).then(pkg => !!(pkg.devDependencies || {}).jest);
+  return getPkg(cwd).then(
+    pkg =>
+      !!(pkg.devDependencies || {}).jest ||
+      (!hasTestFramework(pkg) && isTestScriptUnconfigured(pkg))
+  );
 }
 
 module.exports = {

--- a/lib/tasks/mocha.js
+++ b/lib/tasks/mocha.js
@@ -1,0 +1,40 @@
+/* @flow */
+'use strict';
+
+const path = require('path');
+const updateJsonFile = require('update-json-file');
+
+const { getPkg } = require('../pkg.js');
+const { JSON_OPTIONS, PACKAGE_JSON } = require('../values.js');
+
+const LABEL = 'mocha found and configured';
+
+/* :: import type { TaskOptions } from '../types.js' */
+
+function fn({ cwd } /* : TaskOptions */) {
+  return updateJsonFile(
+    path.join(cwd, 'package.json'),
+    pkg => {
+      if ((pkg.devDependencies || {}).mocha) {
+        pkg.scripts = Object.assign({}, pkg.scripts, {
+          mocha: 'mocha'
+        });
+      }
+
+      return pkg;
+    },
+    JSON_OPTIONS
+  );
+}
+
+function isNeeded({ cwd } /* : TaskOptions */) {
+  return getPkg(cwd).then(pkg => !!(pkg.devDependencies || {}).mocha);
+}
+
+module.exports = {
+  fn,
+  id: path.basename(__filename),
+  isNeeded,
+  label: LABEL,
+  requires: [PACKAGE_JSON]
+};

--- a/lib/tasks/mocha.js
+++ b/lib/tasks/mocha.js
@@ -4,7 +4,7 @@
 const path = require('path');
 const updateJsonFile = require('update-json-file');
 
-const { getPkg } = require('../pkg.js');
+const { addScript, getPkg } = require('../pkg.js');
 const { JSON_OPTIONS, PACKAGE_JSON } = require('../values.js');
 
 const LABEL = 'mocha found and configured';
@@ -16,9 +16,7 @@ function fn({ cwd } /* : TaskOptions */) {
     path.join(cwd, 'package.json'),
     pkg => {
       if ((pkg.devDependencies || {}).mocha) {
-        pkg.scripts = Object.assign({}, pkg.scripts, {
-          mocha: 'mocha'
-        });
+        addScript(pkg, 'mocha', 'mocha');
       }
 
       return pkg;

--- a/lib/text.js
+++ b/lib/text.js
@@ -1,0 +1,16 @@
+/* @flow */
+'use strict';
+
+const os = require('os');
+
+function withLine(text /* : string */, line /* : string */) /* : string */ {
+  const regexp = new RegExp(`\s*${line}\s*`, 'm');
+  if (!regexp.test(text)) {
+    text += `${os.EOL}${line}${os.EOL}`;
+  }
+  return text;
+}
+
+module.exports = {
+  withLine
+};

--- a/lib/text.js
+++ b/lib/text.js
@@ -1,12 +1,14 @@
 /* @flow */
 'use strict';
 
-const os = require('os');
-
 function withLine(text /* : string */, line /* : string */) /* : string */ {
   const regexp = new RegExp(`\s*${line}\s*`, 'm');
+
+  // convert to UNIX line-endings
+  text = text.replace(/\r\n/g, '\n');
+
   if (!regexp.test(text)) {
-    text += `${os.EOL}${line}${os.EOL}`;
+    text += `\n${line}\n`;
   }
   return text;
 }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "nyc": "nyc check-coverage --lines 45",
     "posttest": "npm run eslint && npm run flow_check",
     "pretest": "npm run fixpack && npm run prettier",
-    "test": "npm run ava && npm run nyc",
-    "prettier": "prettier --single-quote --write \"{,!(build|coverage|dist|node_modules)/**/}*.js\""
+    "prettier": "prettier --single-quote --write \"{,!(build|coverage|dist|node_modules)/**/}*.js\"",
+    "test": "npm run ava && npm run nyc"
   }
 }

--- a/package.json
+++ b/package.json
@@ -75,8 +75,8 @@
     "fixpack": "fixpack",
     "flow_check": "flow check",
     "nyc": "nyc check-coverage --lines 45",
-    "posttest": "npm run eslint && npm run flow_check",
-    "pretest": "npm run fixpack && npm run prettier",
+    "posttest": "npm run flow_check",
+    "pretest": "npm run fixpack && npm run prettier && npm run eslint",
     "prettier": "prettier --single-quote --write \"{,!(build|coverage|dist|node_modules)/**/}*.js\"",
     "test": "npm run ava && npm run nyc"
   }

--- a/test/__snapshots__/text.js.snap
+++ b/test/__snapshots__/text.js.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`withLine() 1`] = `
+"
+checkexisting
+  checkwhitespace
+check-hyphen
+"
+`;
+
+exports[`withLine() 2`] = `
+"
+checkexisting
+  checkwhitespace
+check-hyphen
+"
+`;
+
+exports[`withLine() 3`] = `
+"
+checkexisting
+  checkwhitespace
+check-hyphen
+"
+`;
+
+exports[`withLine() 4`] = `
+"
+checkexisting
+  checkwhitespace
+check-hyphen
+
+checkmissing
+"
+`;

--- a/test/text.js
+++ b/test/text.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const test = require('ava');
+
+const { withLine } = require('../lib/text.js');
+
+test('withLine()', t => {
+  const text = `
+checkexisting
+  checkwhitespace
+check-hyphen
+`;
+
+  t.snapshot(withLine(text, 'checkexisting'));
+  t.snapshot(withLine(text, 'checkwhitespace'));
+  t.snapshot(withLine(text, 'check-hyphen'));
+  t.snapshot(withLine(text, 'checkmissing'));
+});


### PR DESCRIPTION
### Added

-   install and configure [jest](https://github.com/facebook/jest) if other test frameworks are absent and `npm test` is not configured

-   populate a ".eslintignore" file to configure ESLint


### Changed

-   example entry-point "index.js" file no longer enables Flow by default

-   move ESLint to "pretest" script, as it may change files (#117)
