### PR TITLE
ensure `prettier` finds target files (fixes #146)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,22 @@
 ## Unreleased
 
 
+### Fixed
+
+-   ensure `prettier` can find target files (#146)
+
+
 ## 2.2.0 - 2017-06-04
 
 
 ### Changed
 
--   update `npm run prettier` options
+-   update `npm run prettier` options (#146)
+
+
+### Notes
+
+-   not published to NPM due to issue (#146)
 
 
 ## 2.1.0 - 2017-04-25

--- a/lib/tasks/prettier.js
+++ b/lib/tasks/prettier.js
@@ -25,7 +25,7 @@ function npmScript(cwd) {
     pkg => {
       pkg.scripts = pkg.scripts || {};
       pkg.scripts.prettier =
-        'prettier --list-different --single-quote --write "{,!(build|coverage|dist|vendor)/**/}*.{css|js|jsx|less|scss|ts|tsx}"';
+        'prettier --list-different --single-quote --write "{,!(build|coverage|dist|vendor)/**/}*.{css,js,jsx,less,scss,ts,tsx}"';
 
       addScript(pkg, 'pretest', 'npm run prettier');
 

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "nyc": "nyc check-coverage --lines 45",
     "posttest": "npm run flow_check",
     "pretest": "npm run fixpack && npm run prettier && npm run eslint",
-    "prettier": "prettier --list-different --single-quote --write \"{,!(build|coverage|dist|vendor)/**/}*.{css|js|jsx|less|scss|ts|tsx}\"",
+    "prettier": "prettier --list-different --single-quote --write \"{,!(build|coverage|dist|vendor)/**/}*.{css,js,jsx,less,scss,ts,tsx}\"",
     "test": "npm run ava && npm run nyc"
   }
 }

--- a/test/prettier.js
+++ b/test/prettier.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const execa = require('execa');
+const test = require('ava');
+
+test('`npm run prettier` finds correct files', async t => {
+  const result = await execa('npm', [
+    'run',
+    'prettier',
+    '--',
+    '--no-list-different'
+  ]);
+  t.regex(result.stdout, /test\/prettier\.js/);
+  t.notRegex(result.stdout, /node_modules/);
+});


### PR DESCRIPTION
### Fixed

-   ensure `prettier` can find target files (#146)
