### PR TITLE
prettier skips vendor type folders (fixes #157)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 ## Unreleased
 
 
+### Fixed
+
+-   `prettier` should skip "flow-typed" and "typings" folders (#157)
+
+
 ## 2.2.3 - 2017-06-18
 
 

--- a/lib/tasks/prettier.js
+++ b/lib/tasks/prettier.js
@@ -25,7 +25,7 @@ function npmScript(cwd) {
     pkg => {
       pkg.scripts = pkg.scripts || {};
       pkg.scripts.prettier =
-        'prettier --list-different --single-quote --write "{,!(build|coverage|dist|vendor)/**/}*.{css,js,jsx,less,scss,ts,tsx}" || exit 0';
+        'prettier --list-different --single-quote --write "{,!(build|coverage|dist|flow-typed|typings|vendor)/**/}*.{css,js,jsx,less,scss,ts,tsx}" || exit 0';
 
       addScript(pkg, 'pretest', 'npm run prettier');
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "nyc": "nyc check-coverage --lines 50",
     "posttest": "npm run flow_check",
     "pretest": "npm run fixpack && npm run prettier && npm run eslint",
-    "prettier": "prettier --list-different --single-quote --write \"{,!(build|coverage|dist|vendor)/**/}*.{css,js,jsx,less,scss,ts,tsx}\" || exit 0",
+    "prettier": "prettier --list-different --single-quote --write \"{,!(build|coverage|dist|flow-typed|typings|vendor)/**/}*.{css,js,jsx,less,scss,ts,tsx}\" || exit 0",
     "test": "npm run ava && npm run nyc"
   }
 }


### PR DESCRIPTION
### Fixed

-   `prettier` should skip "flow-typed" and "typings" folders (#157)
