### PR TITLE
npm-scripts: no more `nsp`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ addons:
     packages:
       - g++-4.8
 node_js:
-  - '8'
   - '10'
   - '11'
 install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- auto-run `npm run fmt` at the end of `node-init`
+
 ### Changed
 
 - auto-raise oldest engines.npm when supported by engines.node

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- auto-raise oldest engines.npm when supported by engines.node
+
 - drop deprecated `sudo: false` from .travis.yml
 
 - drop `nsp` for older engines.npm, end-of-life'd upstream

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - drop deprecated `sudo: false` from .travis.yml
 
+- drop `nsp` for older engines.npm, end-of-life'd upstream
+
 ## [3.3.0] - 2018-07-22
 
 ### Added

--- a/__mocks__/execa.js
+++ b/__mocks__/execa.js
@@ -1,0 +1,12 @@
+/* @flow */
+'use strict';
+
+let result /* : Object */ = {};
+
+module.exports = async () /* : Promise<Object> */ => {
+  return result;
+};
+
+module.exports.__setResult = (r /* : Object */) => {
+  result = r;
+};

--- a/__mocks__/process.js
+++ b/__mocks__/process.js
@@ -1,0 +1,14 @@
+'use strict';
+
+let version = global.process.version;
+
+module.exports = Object.create(global.process, {
+  version: {
+    get: function() {
+      return version;
+    },
+    set: function(value) {
+      version = value;
+    },
+  },
+});

--- a/__tests__/__snapshots__/tasks-npm-engines.js.snap
+++ b/__tests__/__snapshots__/tasks-npm-engines.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`fn() versus empty package.json, new Node.js, new npm 1`] = `
+Object {
+  "engines": Object {
+    "node": ">=8",
+    "npm": ">=6",
+  },
+}
+`;
+
+exports[`fn() versus empty package.json, old Node.js, old npm 1`] = `
+Object {
+  "engines": Object {
+    "node": ">=8",
+    "npm": ">=5",
+  },
+}
+`;
+
+exports[`fn() versus package.json with old engines, new Node.js, new npm 1`] = `
+Object {
+  "engines": Object {
+    "node": ">=10.10",
+    "npm": ">=6",
+  },
+}
+`;

--- a/__tests__/__snapshots__/tasks-npm-scripts.js.snap
+++ b/__tests__/__snapshots__/tasks-npm-scripts.js.snap
@@ -20,11 +20,10 @@ Object {
     "fmt:eslint": "eslint --fix --no-eslintrc --parser-options \\"ecmaVersion:2018,ecmaFeatures:{jsx:true}\\" --rule \\"key-spacing:[error,{align:value}]\\" .",
     "jest": "jest",
     "lint": "npm run eslint",
-    "nsp": "npx -q nsp check",
     "pretest": "npm run fmt",
     "prettier": "npx -q prettier --loglevel=warn --write \\"**/*.{css,js,json,jsx,md,less,scss,ts,tsx}\\"",
     "sort-package-json": "npx -q sort-package-json",
-    "test": "npm run jest && npm run nsp && npm run lint",
+    "test": "npm run jest && npm run lint",
   },
 }
 `;
@@ -50,11 +49,10 @@ Object {
     "fmt:eslint": "eslint --fix --no-eslintrc --parser-options \\"ecmaVersion:2018,ecmaFeatures:{jsx:true}\\" --rule \\"key-spacing:[error,{align:value}]\\" .",
     "jest": "jest",
     "lint": "npm run eslint && npm run flow",
-    "nsp": "npx -q nsp check",
     "pretest": "npm run fmt",
     "prettier": "npx -q prettier --loglevel=warn --write \\"**/*.{css,js,json,jsx,md,less,scss,ts,tsx}\\"",
     "sort-package-json": "npx -q sort-package-json",
-    "test": "npm run jest && npm run nsp && npm run lint",
+    "test": "npm run jest && npm run lint",
   },
 }
 `;
@@ -82,11 +80,10 @@ Object {
     "fmt:eslint": "eslint --fix --no-eslintrc --parser-options \\"ecmaVersion:2018,ecmaFeatures:{jsx:true}\\" --rule \\"key-spacing:[error,{align:value}]\\" .",
     "jest": "jest",
     "lint": "npm run eslint",
-    "nsp": "npx -q nsp check",
     "pretest": "npm run fmt",
     "prettier": "npx -q prettier --loglevel=warn --write \\"**/*.{css,js,json,jsx,md,less,scss,ts,tsx}\\"",
     "sort-package-json": "npx -q sort-package-json",
-    "test": "npm run jest && npm run nsp && npm run lint",
+    "test": "npm run jest && npm run lint",
   },
 }
 `;
@@ -138,12 +135,11 @@ Object {
     "fmt": "npm run sort-package-json && npm run prettier && npm run fmt:eslint",
     "fmt:eslint": "eslint --fix --no-eslintrc --parser-options \\"ecmaVersion:2018,ecmaFeatures:{jsx:true}\\" --rule \\"key-spacing:[error,{align:value}]\\" .",
     "lint": "npm run eslint",
-    "nsp": "npx -q nsp check",
     "nyc": "nyc check-coverage",
     "pretest": "npm run fmt",
     "prettier": "npx -q prettier --loglevel=warn --write \\"**/*.{css,js,json,jsx,md,less,scss,ts,tsx}\\"",
     "sort-package-json": "npx -q sort-package-json",
-    "test": "npm run nsp && npm run lint",
+    "test": "npm run lint",
   },
 }
 `;
@@ -163,11 +159,10 @@ Object {
     "fmt": "npm run sort-package-json && npm run prettier && npm run fmt:eslint",
     "fmt:eslint": "eslint --fix --no-eslintrc --parser-options \\"ecmaVersion:2018,ecmaFeatures:{jsx:true}\\" --rule \\"key-spacing:[error,{align:value}]\\" .",
     "lint": "npm run eslint",
-    "nsp": "npx -q nsp check",
     "pretest": "npm run fmt",
     "prettier": "npx -q prettier --loglevel=warn --write \\"**/*.{css,js,json,jsx,md,less,scss,ts,tsx}\\"",
     "sort-package-json": "npx -q sort-package-json",
-    "test": "true && npm run nsp && npm run lint",
+    "test": "true && npm run lint",
   },
 }
 `;
@@ -195,11 +190,10 @@ Object {
     "fmt:eslint": "eslint --fix --no-eslintrc --parser-options \\"ecmaVersion:2018,ecmaFeatures:{jsx:true}\\" --rule \\"key-spacing:[error,{align:value}]\\" .",
     "jest": "jest",
     "lint": "npm run eslint",
-    "nsp": "npx -q nsp check",
     "pretest": "npm run fmt",
     "prettier": "npx -q prettier --loglevel=warn --write \\"**/*.{css,js,json,jsx,md,less,scss,ts,tsx}\\"",
     "sort-package-json": "npx -q sort-package-json",
-    "test": "npm run jest && npm run nsp && npm run lint",
+    "test": "npm run jest && npm run lint",
   },
 }
 `;
@@ -224,11 +218,10 @@ Object {
     "fmt:eslint": "eslint --fix --no-eslintrc --parser-options \\"ecmaVersion:2018,ecmaFeatures:{jsx:true}\\" --rule \\"key-spacing:[error,{align:value}]\\" .",
     "jest": "jest",
     "lint": "npm run eslint",
-    "nsp": "npx -q nsp check",
     "pretest": "npm run fmt",
     "prettier": "npx -q prettier --loglevel=warn --write \\"**/*.{css,js,json,jsx,md,less,scss,ts,tsx}\\"",
     "sort-package-json": "npx -q sort-package-json",
-    "test": "npm run jest && npm run nsp && npm run lint",
+    "test": "npm run jest && npm run lint",
   },
 }
 `;
@@ -253,12 +246,11 @@ Object {
     "fmt:eslint": "eslint --fix --no-eslintrc --parser-options \\"ecmaVersion:2018,ecmaFeatures:{jsx:true}\\" --rule \\"key-spacing:[error,{align:value}]\\" .",
     "jest": "jest",
     "lint": "npm run eslint",
-    "nsp": "npx -q nsp check",
     "postpublish": "true",
     "pretest": "npm run fmt",
     "prettier": "npx -q prettier --loglevel=warn --write \\"**/*.{css,js,json,jsx,md,less,scss,ts,tsx}\\"",
     "sort-package-json": "npx -q sort-package-json",
-    "test": "npm run jest && npm run nsp && npm run lint",
+    "test": "npm run jest && npm run lint",
   },
 }
 `;

--- a/__tests__/git.js
+++ b/__tests__/git.js
@@ -1,5 +1,7 @@
 'use strict';
 
+jest.unmock('execa');
+
 const { mkdtemp } = require('fs');
 const os = require('os');
 const path = require('path');

--- a/__tests__/tasks-appveyor.yml.js
+++ b/__tests__/tasks-appveyor.yml.js
@@ -1,6 +1,8 @@
 /* @flow */
 'use strict';
 
+jest.unmock('execa');
+
 const {
   isNeeded,
   lib: { pruneCache, pruneInstall, updateNodeNpm },

--- a/__tests__/tasks-gitlab-ci.yml.js
+++ b/__tests__/tasks-gitlab-ci.yml.js
@@ -1,6 +1,8 @@
 /* @flow */
 'use strict';
 
+jest.unmock('execa');
+
 const {
   isNeeded,
   lib: { editConfig },

--- a/__tests__/tasks-npm-engines.js
+++ b/__tests__/tasks-npm-engines.js
@@ -1,0 +1,53 @@
+'use strict';
+
+jest.mock('process');
+global.process = require('process');
+
+jest.mock('execa');
+jest.mock('update-json-file');
+
+const { fn } = require('../lib/tasks/npm-engines.js');
+
+const TEN_SECONDS = 10 * 1e3;
+jest.setTimeout(TEN_SECONDS);
+
+test('fn() versus empty package.json, new Node.js, new npm', async () => {
+  process.version = '8.12.0';
+  const pkg = {};
+  const result = { stdout: '6.4.1' };
+  require('execa').__setResult(result);
+  require('update-json-file').__setPackage(pkg);
+
+  await fn({ cwd: 'some/path' });
+
+  expect(pkg).toMatchSnapshot();
+});
+
+test('fn() versus empty package.json, old Node.js, old npm', async () => {
+  process.version = '8.8.1';
+  const pkg = {};
+  const result = { stdout: '5.4.2' };
+  require('execa').__setResult(result);
+  require('update-json-file').__setPackage(pkg);
+
+  await fn({ cwd: 'some/path' });
+
+  expect(pkg).toMatchSnapshot();
+});
+
+test('fn() versus package.json with old engines, new Node.js, new npm', async () => {
+  process.version = '10.15.0';
+  const pkg = {
+    engines: {
+      node: '>=10.10',
+      npm:  '>=4',
+    },
+  };
+  const result = { stdout: '6.4.1' };
+  require('execa').__setResult(result);
+  require('update-json-file').__setPackage(pkg);
+
+  await fn({ cwd: 'some/path' });
+
+  expect(pkg).toMatchSnapshot();
+});

--- a/__tests__/tasks-travis.yml.js
+++ b/__tests__/tasks-travis.yml.js
@@ -1,6 +1,8 @@
 /* @flow */
 'use strict';
 
+jest.unmock('execa');
+
 const {
   isNeeded,
   lib: { pruneCache, pruneInstall, updateNpm },

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 build: 'off'
 environment:
   matrix:
-    - nodejs_version: '8'
     - nodejs_version: '10'
     - nodejs_version: '11'
 install:

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ const path = require('path');
 const { promisify } = require('util');
 
 const { hasAnnotatedFiles } = require('detect-flowtype');
+const execa = require('execa');
 const logUpdate = require('log-update');
 
 const git = require('./git.js');
@@ -81,6 +82,7 @@ async function init([dir] /* : string[] */, flags /* : Flags */) {
       scope,
     });
   }
+  await execa('npm', ['run', 'fmt'], { cwd: projectDir });
 }
 
 module.exports = {

--- a/lib/tasks/npm-engines.js
+++ b/lib/tasks/npm-engines.js
@@ -4,19 +4,21 @@
 const path = require('path');
 
 const execa = require('execa');
-const semver = require('semver');
+const { intersects, major } = require('semver');
 const updateJsonFile = require('update-json-file');
 
 const { JSON_OPTIONS, PACKAGE_JSON } = require('../values.js');
 
+// https://nodejs.org/en/download/releases/
+const NODE_RANGE_WITH_OLD_NPM = '<8.12 || >=9 <10.2.1';
 const LABEL = '"engines" set in package.json';
 
 /* :: import type { TaskOptions } from '../types.js' */
 
 function fn({ cwd } /* : TaskOptions */) {
-  const node = semver.major(process.version);
+  const node = major(process.version);
   return execa('npm', ['--version'])
-    .then(result => semver.major(result.stdout))
+    .then(result => major(result.stdout))
     .then(npm =>
       updateJsonFile(
         path.join(cwd, 'package.json'),
@@ -24,6 +26,18 @@ function fn({ cwd } /* : TaskOptions */) {
           pkg.engines = pkg.engines || {};
           pkg.engines.node = pkg.engines.node || `>=${node}`;
           pkg.engines.npm = pkg.engines.npm || `>=${npm}`;
+
+          // make special effort here to lift minimum npm to 6.x,
+          // when all supported Node.js versions come with npm 6.x,
+          // as it offers `npm audit` which is desirable
+          if (
+            npm >= 6 &&
+            intersects(pkg.engines.npm, '<6') &&
+            !intersects(pkg.engines.node, NODE_RANGE_WITH_OLD_NPM)
+          ) {
+            pkg.engines.npm = `>=${npm}`;
+          }
+
           return pkg;
         },
         JSON_OPTIONS,

--- a/lib/tasks/npm-scripts.js
+++ b/lib/tasks/npm-scripts.js
@@ -20,15 +20,12 @@ const LABEL = 'npm scripts configured';
 
 function audit(pkg /* : Object */) {
   // npm 6.x has built-in "audit" command
-  if (!pkg.engines || !pkg.engines.npm || intersects(pkg.engines.npm, '<6')) {
-    pkg.scripts.nsp = 'npx -q nsp check';
-    addScript(pkg, 'test', 'npm run nsp');
-  } else {
+  if (pkg.engines && pkg.engines.npm && !intersects(pkg.engines.npm, '<6')) {
     addScript(pkg, 'test', 'npm audit');
-
-    delete pkg.scripts.nsp;
-    removeScript(pkg, 'test', 'npm run nsp');
   }
+  // `nsp` has been decommissioned upstream
+  delete pkg.scripts.nsp;
+  removeScript(pkg, 'test', 'npm run nsp');
   return pkg;
 }
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "collectCoverage": true,
     "coverageThreshold": {
       "global": {
-        "lines": 60
+        "lines": 65
       }
     }
   },


### PR DESCRIPTION
### Added

- auto-run `npm run fmt` at the end of `node-init`

### Changed

- auto-raise oldest engines.npm when supported by engines.node

- drop `nsp` for older engines.npm, end-of-life'd upstream